### PR TITLE
Updated Readme file to use relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Our primary server is up and running at https://airsports.no/ for anyone to use 
 ASLT can be run locally using the docker-compose.yml file, and it is designed to be deployed to GKE using helm.  There are two accompanying apps, [Airsports Google Play](https://play.google.com/store/apps/details?id=no.airsports.android.livetracking&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1) and [Airsport Apple Appstore](https://apps.apple.com/us/app/air-sports-live-tracking/id1559193686?itsct=apps_box&itscg=30200) that integrate with the user management system of ASLT. The repository includes a client also for Microsoft flight simulator 2020 (MFSFS2020).
 
 # Documentation
-A user manual for content creators is available [here](https://github.com/kolaf/airsportslivetracking/blob/main/documentation/Airsports%20Live%20Tracking%20user%20manual.pdf). It is a bit outdated and contributions are welcome. An additional user manual for the results service can be downloaded [here](https://github.com/kolaf/airsportslivetracking/blob/main/documentation/Using%20the%20Air%20Sports%20Live%20Tracking%20results%20service.docx).
+A user manual for content creators is available [here](documentation/Airsports%20Live%20Tracking%20user%20manual.pdf). It is a bit outdated and contributions are welcome. An additional user manual for the results service can be downloaded [here](documentation/Using%20the%20Air%20Sports%20Live%20Tracking%20results%20service.docx).
 
 ## API
-The API is documented using [swagger](https://airsports.no/docs/). This [guide](https://github.com/kolaf/airsportslivetracking/blob/main/documentation/AirSports%20third%20party%20contest%20tool%20API.docx) provides a brief overview of how to use the api to create new navigation tasks and manage contestants.
+The API is documented using [swagger](https://airsports.no/docs/). This [guide](documentation/AirSports%20third%20party%20contest%20tool%20API.docx) provides a brief overview of how to use the api to create new navigation tasks and manage contestants.
 
 ## Tracking
 ASLT uses the [traccar.org](traccar.org) open source tracking server for receiving position reports from users. This allows for support of a wide range of hardware and software trackers.
@@ -20,7 +20,7 @@ The project welcomes contributions of all kinds in the form of pull requests. Ar
 - Translation
 - New task types
 
-The project is currently in the early stages of open source release, so some work is required to clean up the code base to make it more easily maintainable. Check the [implementation guide](https://github.com/airsports-no/airsportslivetracking/wiki/Implementation-guide) for some hints.
+The project is currently in the early stages of open source release, so some work is required to clean up the code base to make it more easily maintainable. Check the [implementation guide](../../wiki/Implementation-guide) for some hints.
 
 ### Structure
 Everything is built upon Django, React, and Python 3.12. Refer to [the wiki](../../wiki/Model-architecture) for a brief description of the most important models. Information about the scoring engine and how the live tracking works is found in [this wiki page](../../wiki/Scoring-engine)


### PR DESCRIPTION
Some of the links in the current Readme file are targeting @kolaf's private fork. This PR updates the links to be related to whatever is the currently viewed repo. 

Link updated for both content hosted in the repo as well as link to the wiki.