### PR TITLE
fix(docker-compose.yml) Set traccar variant to be Ubuntu based for multiarch purpose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       - redis
 
   traccar:
-    image: traccar/traccar
+    image: traccar/traccar:ubuntu
     restart: unless-stopped
     container_name: traccar
     volumes:


### PR DESCRIPTION
With the spread of ARM architecture via Apple Silicon on Mac, it's more and more common to have developers needing multi-architecture docker images.

The default traccar image is an Alpine one only providing AMD64 variant.

This update to the docker-compose set the traccar image variant to be ubuntu, which is a multi-arch image.