### PR TITLE
Fix #69: Reduce map clutter on curved segments

### DIFF
--- a/src/display/flight_order_and_maps/generate_flight_orders.py
+++ b/src/display/flight_order_and_maps/generate_flight_orders.py
@@ -584,12 +584,9 @@ def generate_flight_orders_latex(contestant: "Contestant") -> bytes:
                 for waypoint in contestant.navigation_task.route.waypoints:
                     if not first_line:
                         accumulated_distance += waypoint.distance_previous
-                    if (
-                        waypoint.type not in ("secret", "dummy", "ul")
-                        or (
-                            contestant.navigation_task.scorecard.calculator == ANR_CORRIDOR
-                            and (waypoint.time_check or waypoint.gate_check)
-                        )
+                    if waypoint.type not in ("secret", "dummy", "ul") or (
+                        contestant.navigation_task.scorecard.calculator == ANR_CORRIDOR
+                        and not waypoint.on_curved_segment
                     ):
                         bearing = waypoint.bearing_from_previous
                         wind_correction_angle = calculate_wind_correction_angle(

--- a/src/display/flight_order_and_maps/generate_flight_orders.py
+++ b/src/display/flight_order_and_maps/generate_flight_orders.py
@@ -586,7 +586,10 @@ def generate_flight_orders_latex(contestant: "Contestant") -> bytes:
                         accumulated_distance += waypoint.distance_previous
                     if (
                         waypoint.type not in ("secret", "dummy", "ul")
-                        or contestant.navigation_task.scorecard.calculator == ANR_CORRIDOR
+                        or (
+                            contestant.navigation_task.scorecard.calculator == ANR_CORRIDOR
+                            and (waypoint.time_check or waypoint.gate_check)
+                        )
                     ):
                         bearing = waypoint.bearing_from_previous
                         wind_correction_angle = calculate_wind_correction_angle(

--- a/src/display/flight_order_and_maps/map_plotter.py
+++ b/src/display/flight_order_and_maps/map_plotter.py
@@ -779,7 +779,7 @@ def plot_anr_corridor_track(
         if waypoint.type not in (SECRETPOINT,) or (
             contestant
             and contestant.navigation_task.scorecard.calculator == ANR_CORRIDOR
-            and (waypoint.time_check or waypoint.gate_check)
+            and not waypoint.on_curved_segment
         ):
             plot_waypoint_name(
                 route,
@@ -832,7 +832,7 @@ def maybe_plot_leg_bearing_anr(
     colour: str,
 ):
     next_index = index + 1
-    if next_index >= len(track) or track[next_index].end_curved:
+    if next_index >= len(track) or waypoint.on_curved_segment:
         return
     if (
         track[next_index].type not in (UNKNOWN_LEG, DUMMY) and track[next_index].distance_previous / 1852 > 1
@@ -852,13 +852,11 @@ def maybe_plot_leg_bearing_anr(
 def maybe_plot_leg_bearing(
     waypoint: Waypoint, index: int, track: List[Waypoint], contestant: Contestant, character_offset: int, font_size: int
 ):
-    if waypoint.type != SECRETPOINT:
+    if waypoint.type != SECRETPOINT and not waypoint.on_curved_segment:
         # Only plot bearing if there is a straight line between one not secret gate and the next
         next_index = index + 1
         accumulated_distance = 0
         while next_index < len(track):
-            if track[next_index].end_curved:
-                break
             if (
                 abs(
                     bearing_difference(
@@ -911,8 +909,6 @@ def plot_minute_marks(
     :return:
     """
     next_waypoint = track[index + 1]
-    if next_waypoint.end_curved:
-        return
     gate_start_time = contestant.gate_times.get(waypoint.name)
     if waypoint.is_procedure_turn:
         gate_start_time += datetime.timedelta(minutes=1)

--- a/src/display/flight_order_and_maps/map_plotter.py
+++ b/src/display/flight_order_and_maps/map_plotter.py
@@ -777,7 +777,9 @@ def plot_anr_corridor_track(
         bearing = waypoint_bearing(waypoint, index)
 
         if waypoint.type not in (SECRETPOINT,) or (
-            contestant and contestant.navigation_task.scorecard.calculator == ANR_CORRIDOR
+            contestant
+            and contestant.navigation_task.scorecard.calculator == ANR_CORRIDOR
+            and (waypoint.time_check or waypoint.gate_check)
         ):
             plot_waypoint_name(
                 route,
@@ -830,7 +832,7 @@ def maybe_plot_leg_bearing_anr(
     colour: str,
 ):
     next_index = index + 1
-    if next_index >= len(track):
+    if next_index >= len(track) or track[next_index].end_curved:
         return
     if (
         track[next_index].type not in (UNKNOWN_LEG, DUMMY) and track[next_index].distance_previous / 1852 > 1
@@ -855,6 +857,8 @@ def maybe_plot_leg_bearing(
         next_index = index + 1
         accumulated_distance = 0
         while next_index < len(track):
+            if track[next_index].end_curved:
+                break
             if (
                 abs(
                     bearing_difference(
@@ -907,6 +911,8 @@ def plot_minute_marks(
     :return:
     """
     next_waypoint = track[index + 1]
+    if next_waypoint.end_curved:
+        return
     gate_start_time = contestant.gate_times.get(waypoint.name)
     if waypoint.is_procedure_turn:
         gate_start_time += datetime.timedelta(minutes=1)

--- a/src/display/models/editable_route.py
+++ b/src/display/models/editable_route.py
@@ -277,7 +277,7 @@ class EditableRoute(models.Model):
                             w = prev_width + (curr_width - prev_width) * t
 
                         waypoint_list.append(
-                            build_waypoint(f"Curve {index}.{i}", p_lat, p_lon, "secret", w, False, False)
+                            build_waypoint(f"Curve {index}.{i}", p_lat, p_lon, "secret", w, False, False, end_curved=True)
                         )
 
             # Add the current waypoint

--- a/src/display/models/editable_route.py
+++ b/src/display/models/editable_route.py
@@ -277,7 +277,9 @@ class EditableRoute(models.Model):
                             w = prev_width + (curr_width - prev_width) * t
 
                         waypoint_list.append(
-                            build_waypoint(f"Curve {index}.{i}", p_lat, p_lon, "secret", w, False, False, end_curved=True)
+                            build_waypoint(
+                                f"Curve {index}.{i}", p_lat, p_lon, "secret", w, False, False, on_curved_segment=True
+                            )
                         )
 
             # Add the current waypoint

--- a/src/display/utilities/route_building_utilities.py
+++ b/src/display/utilities/route_building_utilities.py
@@ -282,6 +282,7 @@ def build_waypoint(
     control_latitude=None,
     control_longitude=None,
     end_curved: bool = False,
+    on_curved_segment: bool = False,
 ) -> Waypoint:
     waypoint = Waypoint(name)
     waypoint.latitude = latitude
@@ -295,6 +296,7 @@ def build_waypoint(
     waypoint.time_check = time_check
     waypoint.gate_check = gate_check
     waypoint.end_curved = end_curved
+    waypoint.on_curved_segment = on_curved_segment
     return waypoint
 
 

--- a/src/display/waypoint.py
+++ b/src/display/waypoint.py
@@ -23,6 +23,7 @@ class Waypoint:
         self.gate_check = False
         self.planning_test = False
         self.end_curved = False
+        self.on_curved_segment = False
         self.type = ""
         self.distance_next = -1  # meters type: float
         self.distance_previous = -1  # meters type: float
@@ -31,8 +32,8 @@ class Waypoint:
         self.is_procedure_turn = False
         self.is_steep_turn = False
 
-        self.control_latitude: float|None = None
-        self.control_longitude: float|None = None
+        self.control_latitude: float | None = None
+        self.control_longitude: float | None = None
 
         self.inside_distance = 0
         self.outside_distance = 0


### PR DESCRIPTION
Implemented suppression of annotations on curved segments. 

- Suppressed minute marks and bearings on curved legs.
- Hidden intermediate curved waypoints in flight order tables.
- Filtered waypoint labels on ANR maps to only show timing/gate points.