### PR TITLE
Fix GKE logging noise: gunicorn log level and missing /assets dir

### DIFF
--- a/config/gunicorn.sh
+++ b/config/gunicorn.sh
@@ -26,7 +26,7 @@ exec gunicorn \
   --threads $NUM_THREADS \
   --timeout 30 \
   --bind=:8002 \
-  --log-level debug \
+  --log-level warning \
   --max-requests 2000 \
   --max-requests-jitter 50 \
   --forwarded-allow-ips="*" \

--- a/config/gunicorn_uvicorn.sh
+++ b/config/gunicorn_uvicorn.sh
@@ -26,7 +26,7 @@ exec gunicorn \
   --threads $NUM_THREADS \
   --timeout 30 \
   --bind=:8003 \
-  --log-level debug \
+  --log-level warning \
   --max-requests 1000 \
   --max-requests-jitter 50 \
   --forwarded-allow-ips="*" \

--- a/src/live_tracking_map/settings.py
+++ b/src/live_tracking_map/settings.py
@@ -292,7 +292,7 @@ if os.environ.get("MODE") == "dev" or IS_UNIT_TESTING:
 
 TEMPORARY_FOLDER = "/tmp"
 
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"), "/assets", "/assets_vite"]
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static"), "/assets_vite"]
 
 LOGGING = LOG_CONFIGURATION
 


### PR DESCRIPTION
## What was wrong

### Bug 1: gunicorn log level too verbose
Both `config/gunicorn.sh` and `config/gunicorn_uvicorn.sh` used `--log-level debug`. Gunicorn writes INFO/DEBUG startup messages (control socket creation, booting workers, signal handling setup) to stderr. GKE captures all stderr output as ERROR severity in Cloud Logging, so these routine startup lines were appearing as errors and flooding the log stream with noise.

### Bug 2: missing `/assets` directory in STATICFILES_DIRS
`src/live_tracking_map/settings.py` listed `/assets` in `STATICFILES_DIRS` alongside `/assets_vite`. The Dockerfile copies content into `/assets_vite` but never creates `/assets`. Django's system check framework emits warning `staticfiles.W004` ("The directory '/assets' in the STATICFILES_DIRS setting does not exist") on every startup and management command invocation.

## What was fixed

- Changed `--log-level debug` to `--log-level warning` in both gunicorn startup scripts so only genuine warnings and errors reach stderr (and therefore Cloud Logging).
- Removed `/assets` from `STATICFILES_DIRS`, leaving `[os.path.join(BASE_DIR, "static"), "/assets_vite"]`. Both remaining directories exist at runtime and the W004 warning is eliminated.