### PR TITLE
Run tracker-celery pod as non-root (fixes #78)

### DIFF
--- a/helm/templates/deployment_tracker_celery.yaml
+++ b/helm/templates/deployment_tracker_celery.yaml
@@ -15,6 +15,10 @@ spec:
         date: "{{ now | unixEpoch }}"
     spec:
       terminationGracePeriodSeconds: 25
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 200
+        fsGroup: 200
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
- Adds a pod-level `securityContext` to the `tracker-celery` Deployment so Celery no longer runs as root.
- Uses uid/gid `200`, which is the `django` system user already defined in the Dockerfile and the owner of `/src` and `/logs`, so no image change is required.

## Why
The worker was logging `SecurityWarning: You're running the worker with superuser privileges`. Dropping privileges on just the Celery pod is the least-invasive fix — other services that share the image continue to run as-is until they get their own securityContext blocks.

Fixes #78

## Test plan
- [ ] Deploy to staging and confirm `tracker-celery` pod starts.
- [ ] Check celery.log to confirm the `SecurityWarning` is gone.
- [ ] Confirm liveness/readiness probes still pass (they run `python /src/celery_*.py`; `/src` is owned by django).
- [ ] Confirm writes to `/logs/celery.log` still succeed.