### PR TITLE
Log firebase token failures as warnings with reason

### DIFF
--- a/src/display/views.py
+++ b/src/display/views.py
@@ -2202,7 +2202,7 @@ def firebase_token_login(request):
         user, decoded_token = firebase_authenticator.authenticate_credentials(token)
         login(request, user, backend="django.contrib.auth.backends.ModelBackend")
     except drf_exceptions.AuthenticationFailed as e:
-        logger.exception("Firebase login with token from app failed")
+        logger.warning("Firebase login with token from app failed: %s", e)
         messages.error(request, f"Login failed: {e}")
     return redirect("/")
 


### PR DESCRIPTION
## Summary
- Expired Firebase ID tokens are an expected condition (apps refresh them on 401), so the full multi-level traceback logged at ERROR level was noisy.
- Downgrades `firebase_token_login` failure log to WARNING and interpolates the exception message so the reason (e.g. `Token expired, ... < ...`) is visible inline without a traceback.

## Test plan
- [ ] Trigger a login with an expired token and verify the Cloud Logging entry is a single WARNING line containing the reason, no traceback.
- [ ] Confirm the user-facing `messages.error` flash is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)