### PR TITLE
fix: import EmailMapLink in display/tasks.py (#92)

### DIFF
--- a/src/display/tasks.py
+++ b/src/display/tasks.py
@@ -19,6 +19,7 @@ from django.core.files.storage import default_storage
 from django.utils.text import slugify
 
 from display.models.contestant import Contestant
+from display.models.email_map_link import EmailMapLink
 from display.models.flymaster_data import FlymasterData
 from live_tracking_map.celery import app
 from live_tracking_map.settings import REDIS_HOST, REDIS_PORT, REDIS_PASSWORD


### PR DESCRIPTION
## Summary
- Adds missing `from display.models.email_map_link import EmailMapLink` to `src/display/tasks.py`.
- Resolves `NameError: name 'EmailMapLink' is not defined` raised in `tracker-celery` during flight order generation.
- `EmailMapLink` is referenced in three tasks (`generate_and_maybe_notify_flight_order`, `notify_flight_order`, `delete_old_flight_orders`) without being imported.

Fixes #92

## Test plan
- [ ] Deploy to staging and trigger a flight order generation to confirm the Celery task completes without `NameError`.
- [ ] Confirm `delete_old_flight_orders` periodic task runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)