### PR TITLE
fix: seed liveness cache key before first connection check (issue #85)

### DIFF
--- a/src/position_processor.py
+++ b/src/position_processor.py
@@ -132,6 +132,7 @@ if __name__ == "__main__":
     ).start()
 
     probes.readiness(True)
+    cache.set(LAST_DEBUG_KEY, time.time(), 10 * DEBUG_INTERVAL)
     check_connection()
     print_messages_debug()
     failed_connecting_count = 0


### PR DESCRIPTION
## Summary

- Fixes a startup race condition where `cache.clear()` wipes `LAST_DEBUG_KEY` and `check_connection()` is called immediately — before the `initial_processor` subprocess has had time to set the key
- This caused liveness to be set to `false` on every pod start, triggering Kubernetes restarts (12 occurrences logged)
- Fix: seed `LAST_DEBUG_KEY` in the main process right before `check_connection()` is invoked, consistent with what `initial_processor()` does in the subprocess

## Root cause

In `position_processor.py` startup sequence:
1. `cache.clear()` — wipes all cache keys
2. `Process(target=initial_processor, ...).start()` — subprocess spawned but not yet running
3. `check_connection()` — called immediately; subprocess hasn't set `LAST_DEBUG_KEY` yet → `not last_debug` is `True` → `probes.liveness(False)`

## Test plan
- [ ] Deploy to GKE and confirm no `"Last debug time is not in the cache"` errors on pod startup
- [ ] Verify liveness probe does not fail during the first 30-second check window

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)