### PR TITLE
fix: stop logging Http404/PermissionDenied as 500 errors (#100)

### DIFF
--- a/src/live_tracking_map/middleware.py
+++ b/src/live_tracking_map/middleware.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponseBadRequest, HttpResponseNotFound
 from django.utils.deprecation import MiddlewareMixin
 import logging
@@ -19,6 +20,11 @@ class HandleKnownExceptionsMiddleware(MiddlewareMixin):
         #     return HttpResponseNotFound(str(exception))
 
 
+# Exceptions that Django turns into non-500 responses — logging them as 500s
+# floods the error monitor with noise (see issue #100).
+_NON_500_EXCEPTIONS = (Http404, PermissionDenied)
+
+
 class Log500ErrorsMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
@@ -28,6 +34,8 @@ class Log500ErrorsMiddleware:
         return response
 
     def process_exception(self, request, exception):
+        if isinstance(exception, _NON_500_EXCEPTIONS):
+            return None
         exc_info = (type(exception), exception, exception.__traceback__)
         logger.error("Intercepted 500 error", exc_info=exc_info)
         return None  # Let other middlewares do further processing


### PR DESCRIPTION
## Summary
- `Log500ErrorsMiddleware` currently logs every exception reaching `process_exception` — including `Http404` and `PermissionDenied`, which Django turns into 404/403 responses, not 500s.
- Issue #100 was triggered by an ordinary missing-NavigationTask 404 from `old_tracking_map_redirect` being labelled "Intercepted 500 error" in Stackdriver, which then fired the GKE log monitor.
- Skipping these exception types removes the false positive and lets real 500s stand out again.

## Test plan
- [ ] Hit a `get_object_or_404` URL with a bad PK (e.g. `/display/task/99999999/map/`) in staging and confirm no `Intercepted 500 error` entry appears in Stackdriver.
- [ ] Trigger a genuine `ZeroDivisionError` view in staging and confirm the `Intercepted 500 error` log is still produced.
- [ ] Confirm the existing `HandleKnownExceptionsMiddleware` ValueError → 400 path is unchanged.

Companion change (workspace-only, not in this repo): the GKE log monitor now keeps full stack traces and fetches surrounding pod log lines so the LLM can tell a 404-in-disguise from a real 500 going forward.