### PR TITLE
fix: retry MySQL lock-wait-timeout in ContestantTrack.increment_score (#99)

### DIFF
--- a/src/display/models/contestant_track.py
+++ b/src/display/models/contestant_track.py
@@ -2,6 +2,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import F
 
+from display.utilities.db_retry import retry_on_lock_timeout
+
 
 class ContestantTrack(models.Model):
     """
@@ -78,24 +80,20 @@ class ContestantTrack(models.Model):
             self.__push_change()
 
     def increment_score(self, score_increment):
-        from display.models import TeamTestScore
-
         if score_increment != 0:
             # Atomic update of ContestantTrack score field in the database.
             # We use .update() to avoid the overhead of retrieving the entire object and to be resilient if it was deleted.
-            updated_count = type(self).objects.filter(pk=self.pk).update(score=F("score") + score_increment)
+            updated_count = self._atomic_increment_track_score(score_increment)
 
             if updated_count > 0:
-                # Update task test score if it exists. TeamTestScore has signals for the leaderboard,
-                # so we use .save() with an F expression to keep it atomic while triggering summary updates.
+                # TeamTestScore has signals for the leaderboard, so we use .save() with an F
+                # expression to keep it atomic while triggering summary updates.
                 if hasattr(self.contestant.navigation_task, "tasktest"):
-                    tts, created = TeamTestScore.objects.get_or_create(
-                        team=self.contestant.team,
-                        task_test=self.contestant.navigation_task.tasktest,
-                        defaults={"points": 0},
+                    self._atomic_increment_team_test_score(
+                        self.contestant.team,
+                        self.contestant.navigation_task.tasktest,
+                        score_increment,
                     )
-                    tts.points = F("points") + score_increment
-                    tts.save(update_fields=["points"])
 
                 # Update the instance score locally so that __push_change() sends the most up-to-date information.
                 # Note: This might be slightly different from DB ground truth if there were concurrent updates,
@@ -103,6 +101,23 @@ class ContestantTrack(models.Model):
                 if not isinstance(self.score, F):
                     self.score += score_increment
                 self.__push_change()
+
+    @retry_on_lock_timeout()
+    def _atomic_increment_track_score(self, score_increment) -> int:
+        return type(self).objects.filter(pk=self.pk).update(score=F("score") + score_increment)
+
+    @staticmethod
+    @retry_on_lock_timeout()
+    def _atomic_increment_team_test_score(team, task_test, score_increment) -> None:
+        from display.models import TeamTestScore
+
+        tts, _ = TeamTestScore.objects.get_or_create(
+            team=team,
+            task_test=task_test,
+            defaults={"points": 0},
+        )
+        tts.points = F("points") + score_increment
+        tts.save(update_fields=["points"])
 
     def updates_current_state(self, state: str):
         if self.current_state != state:

--- a/src/display/tests/test_db_retry.py
+++ b/src/display/tests/test_db_retry.py
@@ -1,0 +1,83 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from django.db import OperationalError
+
+from display.utilities.db_retry import is_retryable_lock_error, retry_on_lock_timeout
+
+
+class TestIsRetryableLockError(TestCase):
+    def test_lock_wait_timeout_is_retryable(self):
+        self.assertTrue(is_retryable_lock_error(OperationalError(1205, "Lock wait timeout exceeded")))
+
+    def test_deadlock_is_retryable(self):
+        self.assertTrue(is_retryable_lock_error(OperationalError(1213, "Deadlock found")))
+
+    def test_too_many_connections_is_not_retryable(self):
+        self.assertFalse(is_retryable_lock_error(OperationalError(1040, "Too many connections")))
+
+    def test_empty_args_is_not_retryable(self):
+        self.assertFalse(is_retryable_lock_error(OperationalError()))
+
+
+class TestRetryOnLockTimeout(TestCase):
+    def test_succeeds_without_retry(self):
+        calls = {"n": 0}
+
+        @retry_on_lock_timeout()
+        def fn():
+            calls["n"] += 1
+            return "ok"
+
+        self.assertEqual("ok", fn())
+        self.assertEqual(1, calls["n"])
+
+    def test_retries_lock_timeout_then_succeeds(self):
+        attempts = {"n": 0}
+
+        @retry_on_lock_timeout(max_attempts=3, base_delay=0)
+        def fn():
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise OperationalError(1205, "Lock wait timeout exceeded")
+            return "ok"
+
+        with patch("time.sleep"):
+            self.assertEqual("ok", fn())
+        self.assertEqual(3, attempts["n"])
+
+    def test_gives_up_after_max_attempts(self):
+        attempts = {"n": 0}
+
+        @retry_on_lock_timeout(max_attempts=2, base_delay=0)
+        def fn():
+            attempts["n"] += 1
+            raise OperationalError(1205, "Lock wait timeout exceeded")
+
+        with patch("time.sleep"), self.assertRaises(OperationalError):
+            fn()
+        self.assertEqual(2, attempts["n"])
+
+    def test_non_retryable_code_propagates_immediately(self):
+        attempts = {"n": 0}
+
+        @retry_on_lock_timeout(max_attempts=5, base_delay=0)
+        def fn():
+            attempts["n"] += 1
+            raise OperationalError(1040, "Too many connections")
+
+        with self.assertRaises(OperationalError):
+            fn()
+        self.assertEqual(1, attempts["n"])
+
+    def test_other_exception_propagates_immediately(self):
+        attempts = {"n": 0}
+
+        @retry_on_lock_timeout(max_attempts=5, base_delay=0)
+        def fn():
+            attempts["n"] += 1
+            raise ValueError("nope")
+
+        with self.assertRaises(ValueError):
+            fn()
+        self.assertEqual(1, attempts["n"])

--- a/src/display/utilities/db_retry.py
+++ b/src/display/utilities/db_retry.py
@@ -1,0 +1,65 @@
+"""Retry helpers for transient MySQL errors (lock wait timeout, deadlock)."""
+
+import logging
+import random
+import time
+from functools import wraps
+from typing import Callable, TypeVar
+
+from django.db import OperationalError
+
+logger = logging.getLogger(__name__)
+
+# MySQL error codes that indicate a transient contention issue.
+# The transaction is rolled back by the server, so retrying is safe.
+#   1205 — Lock wait timeout exceeded; try restarting transaction
+#   1213 — Deadlock found when trying to get lock; try restarting transaction
+_RETRYABLE_MYSQL_CODES = (1205, 1213)
+
+T = TypeVar("T")
+
+
+def is_retryable_lock_error(exc: OperationalError) -> bool:
+    code = exc.args[0] if exc.args else None
+    return code in _RETRYABLE_MYSQL_CODES
+
+
+def retry_on_lock_timeout(
+    max_attempts: int = 4,
+    base_delay: float = 0.1,
+    max_delay: float = 2.0,
+) -> Callable:
+    """Retry a callable on MySQL lock-wait-timeout / deadlock errors.
+
+    Uses exponential backoff with jitter. Non-retryable ``OperationalError``
+    codes (and all other exceptions) propagate immediately. Only statements
+    that are rolled back by the server should be wrapped — at that point the
+    partial work is gone and retrying applies the operation exactly once.
+    """
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapper(*args, **kwargs) -> T:
+            attempt = 1
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except OperationalError as exc:
+                    if not is_retryable_lock_error(exc) or attempt >= max_attempts:
+                        raise
+                    delay = min(max_delay, base_delay * (2 ** (attempt - 1)))
+                    delay += random.uniform(0, base_delay)
+                    logger.warning(
+                        "MySQL lock error %s in %s (attempt %d/%d); retrying in %.2fs",
+                        exc.args[0] if exc.args else "?",
+                        func.__qualname__,
+                        attempt,
+                        max_attempts,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    attempt += 1
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary
- Live scoring sporadically drops increments when MySQL raises `OperationalError 1205` ("Lock wait timeout exceeded") inside `tts.save(update_fields=["points"])`. The exception propagates up to `score_updater_thread`, which only logs it — so the score update is lost.
- Add `display.utilities.db_retry.retry_on_lock_timeout`: a small decorator that retries `OperationalError` codes `1205` (lock wait timeout) and `1213` (deadlock) with exponential backoff + jitter, 4 attempts by default. Other `OperationalError` codes and non-DB exceptions propagate immediately.
- Split the two DB statements in `ContestantTrack.increment_score` into separate retryable helpers (`_atomic_increment_track_score` and `_atomic_increment_team_test_score`). Each statement is individually wrapped so a retry applies the operation exactly once — MySQL rolls the statement back on lock timeout, so re-executing the `F`-expression increment is safe.
- Unit tests cover the predicate and decorator behaviour (success, retry-then-success, exhaustion, non-retryable code, non-DB exception).

## Test plan
- [ ] `pytest src/display/tests/test_db_retry.py` passes.
- [ ] Under contest load in staging, tail the `calculator-job` pod logs and confirm:
  - Warnings of the form `MySQL lock error 1205 in ContestantTrack._atomic_increment_team_test_score (attempt 1/4); retrying in 0.12s` appear when contention is high.
  - The "Failed processing score message in thread" traceback no longer fires for 1205 errors.
- [ ] Scores remain consistent between `ContestantTrack.score` and `TeamTestScore.points` after the run.

Closes #99.