### PR TITLE
Diagnose & repair lat/lon-swapped routes from 0120 migration (#65)

### DIFF
--- a/src/display/management/commands/find_swapped_routes.py
+++ b/src/display/management/commands/find_swapped_routes.py
@@ -1,0 +1,196 @@
+"""
+Find EditableRoute rows whose coordinates appear to be stored with lat/lon
+swapped, most likely due to the partial migration 0120_auto_20251228_2126
+(see issue #65).
+
+Strategy: for each route, find the linked Contest (via NavigationTask) and
+compare the route's bounding-box centroid to the contest location. If the
+centroid is far from the contest and becomes much closer when all route
+coordinates are swapped, flag the route as SUSPICIOUS.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from django.core.management.base import BaseCommand
+
+from display.models import Contest, EditableRoute, NavigationTask
+from display.utilities.coordinate_utilities import calculate_distance_lat_lon
+
+
+@dataclass
+class ContestRef:
+    contest_id: int
+    name: str
+    latitude: Optional[float]
+    longitude: Optional[float]
+    country: Optional[str]
+
+
+def _iter_coord_pairs(geometry: dict) -> Iterable[list]:
+    """Yield every [x, y] pair in a GeoJSON geometry (Point/LineString/Polygon)."""
+    gtype = geometry.get("type")
+    coords = geometry.get("coordinates")
+    if coords is None:
+        return
+    if gtype == "Point":
+        yield coords
+    elif gtype == "LineString":
+        yield from coords
+    elif gtype == "Polygon":
+        for ring in coords:
+            yield from ring
+    else:
+        return
+
+
+def route_bbox_centroid(route: dict) -> Optional[tuple[float, float]]:
+    """Return (lon, lat) centroid of bbox over all feature coordinates."""
+    lons: list[float] = []
+    lats: list[float] = []
+    for feature in route.get("features", []) or []:
+        geom = feature.get("geometry") or {}
+        for pair in _iter_coord_pairs(geom):
+            if not pair or len(pair) < 2:
+                continue
+            lon, lat = pair[0], pair[1]
+            lons.append(lon)
+            lats.append(lat)
+    if not lons:
+        return None
+    return (
+        (min(lons) + max(lons)) / 2.0,
+        (min(lats) + max(lats)) / 2.0,
+    )
+
+
+def contest_for_route(route: EditableRoute) -> Optional[ContestRef]:
+    """Find the first Contest linked to this route via NavigationTask."""
+    nav = (
+        NavigationTask.objects.filter(editable_route=route)
+        .select_related("contest")
+        .first()
+    )
+    if not nav or not nav.contest:
+        return None
+    c: Contest = nav.contest
+    lat = getattr(c, "latitude", None)
+    lon = getattr(c, "longitude", None)
+    try:
+        lat = float(lat) if lat is not None else None
+        lon = float(lon) if lon is not None else None
+    except (TypeError, ValueError):
+        lat = lon = None
+    country = str(c.country) if getattr(c, "country", None) else None
+    return ContestRef(contest_id=c.id, name=c.name, latitude=lat, longitude=lon, country=country)
+
+
+def km_between(a: tuple[float, float], b: tuple[float, float]) -> float:
+    """Distance in km between two (lon, lat) points."""
+    a_lat_lon = (a[1], a[0])
+    b_lat_lon = (b[1], b[0])
+    return calculate_distance_lat_lon(a_lat_lon, b_lat_lon) / 1000.0
+
+
+class Command(BaseCommand):
+    help = (
+        "Identify EditableRoute rows whose coordinates appear to have lat/lon "
+        "swapped by comparing route bbox centroid to the linked Contest location."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--threshold-km",
+            type=float,
+            default=500.0,
+            help="Flag a route if its centroid is farther than this from the contest "
+                 "AND swapping coordinates brings it much closer. Default: 500 km.",
+        )
+        parser.add_argument(
+            "--improvement-ratio",
+            type=float,
+            default=5.0,
+            help="Require swapped distance to be at least this many times smaller "
+                 "than original distance. Default: 5.",
+        )
+        parser.add_argument(
+            "--route-id",
+            type=int,
+            action="append",
+            default=None,
+            help="Limit check to given route id(s). May be repeated.",
+        )
+        parser.add_argument(
+            "--show-all",
+            action="store_true",
+            help="Also print non-suspicious routes (OK, UNLINKED, NO_LOCATION).",
+        )
+
+    def handle(self, *args, **opts):
+        threshold_km: float = opts["threshold_km"]
+        ratio: float = opts["improvement_ratio"]
+        route_ids = opts.get("route_id")
+        show_all: bool = opts["show_all"]
+
+        qs = EditableRoute.objects.all().order_by("id")
+        if route_ids:
+            qs = qs.filter(id__in=route_ids)
+
+        suspicious: list[int] = []
+        header = "id\tverdict\tdist_km\tswapped_km\tcontest_id\tcontest_name\troute_name"
+        self.stdout.write(header)
+
+        for route in qs:
+            centroid = route_bbox_centroid(route.route or {})
+            ref = contest_for_route(route)
+
+            verdict, dist, swapped_dist = self._classify(
+                centroid, ref, threshold_km, ratio
+            )
+            if verdict == "SUSPICIOUS":
+                suspicious.append(route.id)
+
+            if verdict == "SUSPICIOUS" or show_all:
+                contest_id = ref.contest_id if ref else ""
+                contest_name = ref.name if ref else ""
+                self.stdout.write(
+                    f"{route.id}\t{verdict}\t"
+                    f"{self._fmt(dist)}\t{self._fmt(swapped_dist)}\t"
+                    f"{contest_id}\t{contest_name}\t{route.name}"
+                )
+
+        self.stdout.write("")
+        self.stdout.write(f"Suspicious route ids: {suspicious}")
+        self.stdout.write(
+            f"To repair: python manage.py fix_swapped_route "
+            + " ".join(str(i) for i in suspicious)
+        )
+
+    @staticmethod
+    def _fmt(v) -> str:
+        return f"{v:.0f}" if isinstance(v, (int, float)) else ""
+
+    @staticmethod
+    def _classify(
+        centroid: Optional[tuple[float, float]],
+        ref: Optional[ContestRef],
+        threshold_km: float,
+        ratio: float,
+    ) -> tuple[str, Optional[float], Optional[float]]:
+        if centroid is None:
+            return "EMPTY_ROUTE", None, None
+        if ref is None:
+            return "UNLINKED", None, None
+        if ref.latitude is None or ref.longitude is None:
+            return "NO_LOCATION", None, None
+
+        contest_point = (ref.longitude, ref.latitude)
+        dist = km_between(centroid, contest_point)
+        swapped = (centroid[1], centroid[0])
+        swapped_dist = km_between(swapped, contest_point)
+
+        if dist > threshold_km and swapped_dist * ratio < dist:
+            return "SUSPICIOUS", dist, swapped_dist
+        return "OK", dist, swapped_dist

--- a/src/display/management/commands/fix_swapped_route.py
+++ b/src/display/management/commands/fix_swapped_route.py
@@ -1,0 +1,146 @@
+"""
+Repair EditableRoute rows identified by `find_swapped_routes` as having
+lat/lon swapped in their stored GeoJSON FeatureCollection (issue #65).
+
+For each supplied route id, swaps every [x, y] coordinate pair in every
+feature's geometry to [y, x]. Writes a JSON backup of the original route
+field before saving, so the change can be reverted manually if needed.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from display.models import EditableRoute
+
+
+SUPPORTED_GEOMETRY_TYPES = {"Point", "LineString", "Polygon"}
+
+
+def _swap_pair(pair: list) -> list:
+    if not pair or len(pair) < 2:
+        return pair
+    return [pair[1], pair[0], *pair[2:]]
+
+
+def swap_geometry_coordinates(geometry: dict) -> None:
+    """Mutate geometry in place so every coordinate pair is swapped."""
+    gtype = geometry.get("type")
+    if gtype == "Point":
+        geometry["coordinates"] = _swap_pair(geometry.get("coordinates", []))
+    elif gtype == "LineString":
+        geometry["coordinates"] = [_swap_pair(p) for p in geometry.get("coordinates", [])]
+    elif gtype == "Polygon":
+        geometry["coordinates"] = [
+            [_swap_pair(p) for p in ring] for ring in geometry.get("coordinates", [])
+        ]
+    else:
+        raise ValueError(f"Unsupported geometry type: {gtype!r}")
+
+
+def swap_route_coordinates(route: dict) -> dict:
+    """Return a shallow-copied route with every feature geometry coord-swapped."""
+    new_route = {"type": route.get("type", "FeatureCollection"), "features": []}
+    for feature in route.get("features", []) or []:
+        new_feature = dict(feature)
+        geom = dict(feature.get("geometry") or {})
+        swap_geometry_coordinates(geom)
+        new_feature["geometry"] = geom
+        new_route["features"].append(new_feature)
+    return new_route
+
+
+class Command(BaseCommand):
+    help = (
+        "Swap lat/lon in the stored GeoJSON for one or more EditableRoute rows, "
+        "as a repair for routes whose coordinates were left inverted by the "
+        "0120 route-editor data migration. See issue #65."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "route_ids",
+            nargs="+",
+            type=int,
+            help="EditableRoute ids to repair.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be changed without saving.",
+        )
+        parser.add_argument(
+            "--backup-dir",
+            default="route_swap_backups",
+            help="Directory where pre-fix route JSON is written. Default: ./route_swap_backups",
+        )
+
+    def handle(self, *args, **opts):
+        dry_run: bool = opts["dry_run"]
+        backup_dir = Path(opts["backup_dir"])
+        route_ids: list[int] = opts["route_ids"]
+
+        if not dry_run:
+            backup_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+        for rid in route_ids:
+            try:
+                route = EditableRoute.objects.get(id=rid)
+            except EditableRoute.DoesNotExist:
+                raise CommandError(f"EditableRoute {rid} not found")
+
+            original = route.route or {}
+            try:
+                swapped = swap_route_coordinates(original)
+            except ValueError as e:
+                self.stderr.write(self.style.ERROR(f"Route {rid}: {e} — skipping"))
+                continue
+
+            sample_before = self._first_coord(original)
+            sample_after = self._first_coord(swapped)
+            self.stdout.write(
+                f"Route {rid} ({route.name}): "
+                f"first coord {sample_before} -> {sample_after}"
+            )
+
+            if dry_run:
+                continue
+
+            backup_path = backup_dir / f"editable_route_{rid}_{timestamp}.json"
+            with backup_path.open("w", encoding="utf-8") as f:
+                json.dump(original, f, indent=2, default=str)
+            self.stdout.write(f"  backup: {backup_path}")
+
+            route.route = swapped
+            route.save(update_fields=["route"])
+            route.refresh_from_db()
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"  saved (waypoints={route.number_of_waypoints}, "
+                    f"route_length={route.route_length:.0f})"
+                )
+            )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry run — no changes saved."))
+
+    @staticmethod
+    def _first_coord(route: dict):
+        for feature in route.get("features", []) or []:
+            geom = feature.get("geometry") or {}
+            coords = geom.get("coordinates")
+            if not coords:
+                continue
+            if geom.get("type") == "Point":
+                return coords
+            if geom.get("type") == "LineString" and coords:
+                return coords[0]
+            if geom.get("type") == "Polygon" and coords and coords[0]:
+                return coords[0][0]
+        return None


### PR DESCRIPTION
## Summary
- Adds `find_swapped_routes` — a management command that correlates each `EditableRoute` with its owning `Contest` (via `NavigationTask`) and flags routes whose bbox centroid is far from the contest but would snap close if coordinates were swapped.
- Adds `fix_swapped_route <id>…` — swaps every coord pair in every feature geometry (Point / LineString / Polygon) for the given route ids, backing up the pre-fix route JSON to `./route_swap_backups/` first.

## Root cause (hypothesis)
Issue #65 reports routes 1459, 1461, 1463, 1464 rendering in Saudi Arabia instead of Slovakia — a clean lat/lon swap (Slovakia ≈ 17° E, 48° N → stored as (48, 17) which falls in Saudi Arabia).

The 0120 migration (`display/migrations/0120_auto_20251228_2126.py`) runs `convert_legacy_json()` in place on every `EditableRoute.route`. In `display/convert_route.py`:

- Line 21 copies the legacy `track_layer['geojson']['geometry']` straight into the new `route_path` feature without re-ordering coordinates.
- Line 33 builds `[lng, lat]` explicitly when `point['position']` is present (GeoJSON-correct).
- Line 35 (fallback) copies `track_layer['geojson']['geometry']['coordinates'][i]` straight into the waypoint.

For most routes the legacy geojson was stored as `[lng, lat]`. For the affected routes the legacy geojson appears to have been stored as `[lat, lng]` (Leaflet-style), so the path and fallback-waypoint coordinates kept the swap when converted.

## Draft status
Draft because I'd like you to review before running anything against prod:
- the heuristic thresholds (`--threshold-km 500`, `--improvement-ratio 5`) are guesses
- the repair assumes every feature in a flagged route is swapped (true if the root cause is as above; not true if a route was partially edited post-migration)

## Test plan
- [ ] `python manage.py find_swapped_routes` — verify it lists 1459, 1461, 1463, 1464 (or a superset) and doesn't flag known-good routes. `--show-all` to see everything.
- [ ] `python manage.py find_swapped_routes --route-id 1459 --route-id 1461 --route-id 1463 --route-id 1464 --show-all` — confirm all four show `SUSPICIOUS`.
- [ ] `python manage.py fix_swapped_route 1459 --dry-run` — confirm the first-coord swap looks right.
- [ ] Run fix on a single route (e.g. 1459), reload editor, verify it now renders in Slovakia. If good, run on the rest.
- [ ] Verify `route_length` and `number_of_waypoints` get recomputed by the existing `post_save` signal after the fix.

Refs #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)