### PR TITLE
fix: process mbtiles uploads asynchronously (closes #104, #105, #106)

### DIFF
--- a/src/display/migrations/0131_useruploadedmap_processing_status.py
+++ b/src/display/migrations/0131_useruploadedmap_processing_status.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("display", "0130_contestantreceivedposition_projected_x_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="useruploadedmap",
+            name="processing_status",
+            field=models.CharField(
+                choices=[("pending", "Pending"), ("ready", "Ready"), ("failed", "Failed")],
+                default="pending",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="useruploadedmap",
+            name="processing_error",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.RunSQL(
+            sql="UPDATE display_useruploadedmap SET processing_status = 'ready' WHERE thumbnail IS NOT NULL AND thumbnail != '';",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]

--- a/src/display/models/user_uploaded_map.py
+++ b/src/display/models/user_uploaded_map.py
@@ -29,6 +29,15 @@ class UserUploadedMap(models.Model):
     A user uploaded map contains a mbtiles file that conserve tiles to be used as map backgrounds for navigation maps
     (flight orders) created by users with access to the user uploaded map object.
     """
+    PROCESSING_PENDING = "pending"
+    PROCESSING_READY = "ready"
+    PROCESSING_FAILED = "failed"
+    PROCESSING_STATUS_CHOICES = (
+        (PROCESSING_PENDING, "Pending"),
+        (PROCESSING_READY, "Ready"),
+        (PROCESSING_FAILED, "Failed"),
+    )
+
     user = models.ForeignKey("MyUser", on_delete=models.CASCADE)
     name = models.CharField(max_length=500)
     map_file = models.FileField(
@@ -51,6 +60,12 @@ class UserUploadedMap(models.Model):
         help_text="A short attribution text for the map source material (source and time of retrieval), e.g. 'Contains data from kartverket.no, 07/2023",
         max_length=100,
     )
+    processing_status = models.CharField(
+        max_length=16,
+        choices=PROCESSING_STATUS_CHOICES,
+        default=PROCESSING_PENDING,
+    )
+    processing_error = models.TextField(blank=True, default="")
 
     def __str__(self):
         return self.name
@@ -62,15 +77,20 @@ class UserUploadedMap(models.Model):
         """
         Maps are stored in Google file storage. However, matplotlib/cartopy requires the files to be available locally.
         This function ensures that the file has been copied to the local file system and returns the path to it.
+        Streams the file in chunks to avoid loading the entire (up to 100MB) mbtiles into memory at once.
         """
         key = f"user_map_{self.map_file.name}"
         if temporary_path := LOCAL_MAP_FILE_CACHE.get(key):
             return temporary_path
-        else:
-            with NamedTemporaryFile(delete=False) as temporary_map:
-                temporary_map.write(self.map_file.read())
-                LOCAL_MAP_FILE_CACHE[key] = temporary_map.name
-                return temporary_map.name
+        with NamedTemporaryFile(delete=False) as temporary_map:
+            self.map_file.open("rb")
+            try:
+                for chunk in self.map_file.chunks():
+                    temporary_map.write(chunk)
+            finally:
+                self.map_file.close()
+            LOCAL_MAP_FILE_CACHE[key] = temporary_map.name
+            return temporary_map.name
 
     def clear_local_file_path(self):
         """

--- a/src/display/tasks.py
+++ b/src/display/tasks.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 from typing import Optional
 
 import redis_lock
@@ -238,6 +239,47 @@ def delete_old_flight_orders():
     EmailMapLink.objects.filter(
         contestant__finished_by_time__lt=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=5)
     ).delete()
+
+
+@app.task
+def process_user_uploaded_map(map_id: int):
+    """
+    Generate the thumbnail and detect the zoom range for a newly uploaded or updated UserUploadedMap.
+
+    Heavy mbtiles processing (streaming the file locally, stitching tiles into a thumbnail image) is run
+    out-of-band to avoid blocking the gunicorn request worker and exceeding its memory/timeout limits.
+    """
+    from display.models import UserUploadedMap
+
+    try:
+        instance = UserUploadedMap.objects.get(pk=map_id)
+    except UserUploadedMap.DoesNotExist:
+        logger.warning(f"UserUploadedMap {map_id} no longer exists, skipping processing")
+        return
+
+    try:
+        instance.clear_local_file_path()
+        content, minimum_zoom, maximum_zoom = instance.create_thumbnail()
+        filename = os.path.split(instance.map_file.name)[1] + "_thumbnail.png"
+        instance.thumbnail.save(filename, ContentFile(content.getvalue()), save=False)
+        instance.minimum_zoom_level = minimum_zoom
+        instance.maximum_zoom_level = maximum_zoom
+        if not minimum_zoom <= instance.default_zoom_level <= maximum_zoom:
+            clamped = max(minimum_zoom, min(instance.default_zoom_level, maximum_zoom))
+            logger.warning(
+                f"Clamping default_zoom_level for UserUploadedMap {map_id} from "
+                f"{instance.default_zoom_level} to {clamped} (map supports [{minimum_zoom}, {maximum_zoom}])"
+            )
+            instance.default_zoom_level = clamped
+        instance.processing_status = UserUploadedMap.PROCESSING_READY
+        instance.processing_error = ""
+        instance.save()
+    except Exception as ex:
+        logger.exception(f"Failed processing UserUploadedMap {map_id}")
+        UserUploadedMap.objects.filter(pk=map_id).update(
+            processing_status=UserUploadedMap.PROCESSING_FAILED,
+            processing_error=f"Failed reading mbtiles file: {ex}",
+        )
 
 
 @app.task

--- a/src/display/templates/display/useruploadedmap_list.html
+++ b/src/display/templates/display/useruploadedmap_list.html
@@ -7,6 +7,15 @@
             <div class="card bg-base-100 shadow-xl">
                 {% if object.thumbnail %}
                     <figure><img src="{{ object.thumbnail.url }}" alt="{{ object.name }} thumbnail"></figure>
+                {% elif object.processing_status == 'pending' %}
+                    <div class="p-8 text-center text-base-content/70">
+                        <span class="loading loading-spinner loading-md"></span>
+                        <div>Processing mbtiles&hellip; refresh the page in a moment.</div>
+                    </div>
+                {% elif object.processing_status == 'failed' %}
+                    <div class="p-6 text-center text-error text-sm">
+                        Processing failed: {{ object.processing_error }}
+                    </div>
                 {% endif %}
                 <div class="card-body">
                     <h5 class="card-title">{{ object.name }} ({{ object.map_file.size |filesizeformat }})</h5>

--- a/src/display/tests/test_user_uploaded_map.py
+++ b/src/display/tests/test_user_uploaded_map.py
@@ -1,0 +1,89 @@
+from io import BytesIO
+from unittest.mock import patch, MagicMock
+
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from display.models.user_uploaded_map import UserUploadedMap
+from display.tasks import process_user_uploaded_map
+
+
+def _make_instance(user, default_zoom=12) -> UserUploadedMap:
+    return UserUploadedMap.objects.create(
+        user=user,
+        name="test-map",
+        map_file=SimpleUploadedFile("test.mbtiles", b"fake mbtiles bytes"),
+        default_zoom_level=default_zoom,
+    )
+
+
+class ProcessUserUploadedMapTaskTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create(email="taskuser@example.com")
+
+    def test_missing_map_does_not_raise(self):
+        process_user_uploaded_map(999999)
+
+    def test_successful_processing_marks_ready(self):
+        instance = _make_instance(self.user, default_zoom=12)
+
+        fake_png = BytesIO(b"\x89PNG\r\n\x1a\nfake")
+
+        with patch.object(UserUploadedMap, "create_thumbnail", return_value=(fake_png, 10, 14)):
+            process_user_uploaded_map(instance.pk)
+
+        instance.refresh_from_db()
+        self.assertEqual(instance.processing_status, UserUploadedMap.PROCESSING_READY)
+        self.assertEqual(instance.processing_error, "")
+        self.assertEqual(instance.minimum_zoom_level, 10)
+        self.assertEqual(instance.maximum_zoom_level, 14)
+        self.assertEqual(instance.default_zoom_level, 12)
+        self.assertTrue(instance.thumbnail)
+
+    def test_default_zoom_is_clamped_when_outside_range(self):
+        instance = _make_instance(self.user, default_zoom=18)
+        fake_png = BytesIO(b"\x89PNGfake")
+
+        with patch.object(UserUploadedMap, "create_thumbnail", return_value=(fake_png, 10, 14)):
+            process_user_uploaded_map(instance.pk)
+
+        instance.refresh_from_db()
+        self.assertEqual(instance.processing_status, UserUploadedMap.PROCESSING_READY)
+        self.assertEqual(instance.default_zoom_level, 14)
+
+    def test_failure_marks_failed_with_error(self):
+        instance = _make_instance(self.user)
+
+        with patch.object(UserUploadedMap, "create_thumbnail", side_effect=RuntimeError("corrupt mbtiles")):
+            process_user_uploaded_map(instance.pk)
+
+        instance.refresh_from_db()
+        self.assertEqual(instance.processing_status, UserUploadedMap.PROCESSING_FAILED)
+        self.assertIn("corrupt mbtiles", instance.processing_error)
+
+
+class GetLocalFilePathStreamingTests(TestCase):
+    """
+    The old implementation called `self.map_file.read()` which loaded the entire (up to 100MB) mbtiles into
+    memory in a single gunicorn request worker. This test guards against that regression by asserting we
+    use the chunked iterator instead.
+    """
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(email="streamuser@example.com")
+
+    def test_uses_chunks_not_full_read(self):
+        instance = _make_instance(self.user)
+
+        from display.models import user_uploaded_map as module
+        module.LOCAL_MAP_FILE_CACHE.pop(f"user_map_{instance.map_file.name}", None)
+
+        with patch.object(instance.map_file, "chunks", wraps=instance.map_file.chunks) as chunks_mock, \
+             patch.object(instance.map_file, "read", wraps=instance.map_file.read) as read_mock:
+            path = instance.get_local_file_path()
+            self.addCleanup(instance.clear_local_file_path)
+
+        self.assertTrue(path)
+        chunks_mock.assert_called_once()
+        read_mock.assert_not_called()

--- a/src/display/views.py
+++ b/src/display/views.py
@@ -123,6 +123,7 @@ from display.contestant_scheduling.schedule_contestants import schedule_and_crea
 from display.tasks import (
     import_gpx_track,
     process_flymaster_file,
+    process_user_uploaded_map,
     recalculate_existing_positions,
     recalculate_live_data_for_contestant,
 )
@@ -1983,31 +1984,16 @@ class UserUploadedMapCreate(PermissionRequiredMixin, CreateView):
 
     def form_valid(self, form):
         instance = form.save()  # type: UserUploadedMap
-        try:
-            filename = os.path.split(instance.map_file.name)[1] + "_thumbnail.png"
-            content, minimum_zoom, maximum_zoom = instance.create_thumbnail()
-            instance.thumbnail.save(
-                filename,
-                ContentFile(content.getvalue()),
-                save=True,
-            )
-            instance.minimum_zoom_level = minimum_zoom
-            instance.maximum_zoom_level = maximum_zoom
-            if not minimum_zoom <= instance.default_zoom_level <= maximum_zoom:
-                form.add_error(
-                    "default_zoom_level",
-                    f"The selected default zoom level {instance.default_zoom_level} is not in the range supported by the map: [{minimum_zoom}, {maximum_zoom}]",
-                )
-                return super().form_invalid(form)
-            instance.save()
-        except Exception as ex:
-            logger.exception("Failed creating thumbnail")
-            form.add_error("map_file", f"Failed reading mbtiles file: {ex}")
-            return super().form_invalid(form)
+        instance.processing_status = UserUploadedMap.PROCESSING_PENDING
+        instance.processing_error = ""
+        instance.save(update_fields=["processing_status", "processing_error"])
+
         assign_perm("delete_useruploadedmap", self.request.user, instance)
         assign_perm("view_useruploadedmap", self.request.user, instance)
         assign_perm("add_useruploadedmap", self.request.user, instance)
         assign_perm("change_useruploadedmap", self.request.user, instance)
+
+        transaction.on_commit(lambda: process_user_uploaded_map.delay(instance.pk))
 
         self.object = instance
         return HttpResponseRedirect(self.get_success_url())
@@ -2024,27 +2010,11 @@ class UserUploadedMapUpdate(GuardianPermissionRequiredMixin, UpdateView):
     def form_valid(self, form):
         instance = form.save()  # type: UserUploadedMap
         instance.clear_local_file_path()
-        try:
-            content, minimum_zoom, maximum_zoom = instance.create_thumbnail()
-            filename = os.path.split(instance.map_file.name)[1] + "_thumbnail.png"
-            instance.thumbnail.save(
-                filename,
-                ContentFile(content.getvalue()),
-                save=True,
-            )
-            instance.minimum_zoom_level = minimum_zoom
-            instance.maximum_zoom_level = maximum_zoom
-            if not minimum_zoom <= instance.default_zoom_level <= maximum_zoom:
-                form.add_error(
-                    "default_zoom_level",
-                    f"The selected default zoom level {instance.default_zoom_level} is not in the range supported by the map: [{minimum_zoom}, {maximum_zoom}]",
-                )
-                return super().form_invalid(form)
-            instance.save()
-        except Exception as ex:
-            logger.exception("Failed creating thumbnail")
-            form.add_error("map_file", f"Failed reading mbtiles file: {ex}")
-            return super().form_invalid(form)
+        instance.processing_status = UserUploadedMap.PROCESSING_PENDING
+        instance.processing_error = ""
+        instance.save(update_fields=["processing_status", "processing_error"])
+
+        transaction.on_commit(lambda: process_user_uploaded_map.delay(instance.pk))
 
         self.object = instance
         return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
## Summary
- Root cause for #104, #105 and #106 is the same code path: the `UserUploadedMap` create/update views do all the mbtiles work inside the 30s gunicorn request handler (1 worker, 1 thread), including a full `file.read()` of an up-to-100 MB blob and a 4096 px tile stitch. Large uploads hit `WORKER TIMEOUT` then `SIGKILL`, and the user sees a 500. The DB row survived the crash but permissions were never assigned — so the map didn't show up in *My maps* but still blocked re-upload with the same name.
- Stream `map_file` via `FieldFile.chunks()` so `get_local_file_path()` no longer loads the full file into RAM.
- Move thumbnail generation and zoom-range detection into a new Celery task `process_user_uploaded_map`. The view saves the row, assigns perms, and enqueues the task on transaction commit.
- Add `processing_status` / `processing_error` fields so the list view can show pending/failed states. Out-of-range `default_zoom_level` is clamped rather than failing the save.

## Test plan
- [ ] `pytest src/display/tests/test_user_uploaded_map.py` passes (happy path, failure path, zoom clamping, streaming regression guard).
- [ ] Manual: upload a large mbtiles (~80 MB) and confirm the request returns quickly; the list shows a "Processing…" placeholder that is replaced by the thumbnail after the Celery task finishes.
- [ ] Manual: upload a corrupt/tiny mbtiles and confirm the list shows the processing error, and that the user can delete the row.
- [ ] Manual: update an existing map with a new mbtiles and confirm the thumbnail refreshes.
- [ ] Migration 0131_useruploadedmap_processing_status applies cleanly (existing maps with a thumbnail are back-filled to ready).

Fixes #104
Fixes #105
Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)