### PR TITLE
feat: batch update contestants wind and times (#108)

### DIFF
--- a/src/display/forms.py
+++ b/src/display/forms.py
@@ -625,6 +625,73 @@ class ContestantQuickAddForm(forms.Form):
         )
 
 
+import datetime
+from django import forms
+from django.db.models import QuerySet
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout, Fieldset, Submit, HTML, ButtonHolder, Row, Column
+from django.utils.translation import gettext_lazy as _
+from .models import Contestant, ContestTeam, NavigationTask, ContestantTrack
+
+class BatchContestantUpdateForm(forms.Form):
+    contestant_ids = forms.MultipleChoiceField(
+        widget=forms.CheckboxSelectMultiple,
+        required=True,
+        label="Contestants",
+    )
+    update_wind = forms.BooleanField(required=False, label="Update wind speed/direction")
+    wind_speed = forms.FloatField(required=False, min_value=0, max_value=40, label="Wind speed (km/h)")
+    wind_direction = forms.FloatField(required=False, min_value=0, max_value=360, label="Wind direction (°)")
+    shift_times = forms.BooleanField(required=False, label="Shift contestant times")
+    time_shift_minutes = forms.FloatField(required=False, label="Shift by (minutes, use negative to move earlier)")
+
+    def __init__(self, *args, navigation_task=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.navigation_task = navigation_task
+        if navigation_task:
+            choices = []
+            for c in navigation_task.contestant_set.select_related("contestanttrack").order_by("takeoff_time"):
+                calculator_started = hasattr(c, "contestanttrack") and c.contestanttrack.calculator_started
+                if not calculator_started:
+                    choices.append((str(c.pk), str(c)))
+            self.fields["contestant_ids"].choices = choices
+
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            Fieldset(
+                "Select Contestants",
+                "contestant_ids",
+            ),
+            Fieldset(
+                "Operation: Update Wind",
+                "update_wind",
+                Row(
+                    Column("wind_speed", css_class="form-group col-md-6 mb-0"),
+                    Column("wind_direction", css_class="form-group col-md-6 mb-0"),
+                ),
+            ),
+            Fieldset(
+                "Operation: Shift Times",
+                "shift_times",
+                "time_shift_minutes",
+            ),
+            ButtonHolder(Submit("submit", "Apply Changes", css_class="btn-primary")),
+        )
+
+    def clean(self):
+        cd = super().clean()
+        if cd.get("update_wind"):
+            if cd.get("wind_speed") is None:
+                self.add_error("wind_speed", "Wind speed is required when updating wind.")
+            if cd.get("wind_direction") is None:
+                self.add_error("wind_direction", "Wind direction is required when updating wind.")
+        if cd.get("shift_times") and cd.get("time_shift_minutes") is None:
+            self.add_error("time_shift_minutes", "Shift amount is required when shifting times.")
+        if not cd.get("update_wind") and not cd.get("shift_times"):
+            raise forms.ValidationError("Please select at least one operation (update wind or shift times).")
+        return cd
+
+
 class ContestantRecalculateWithStartTimeForm(forms.Form):
     starting_point_time = forms.DateTimeField(
         label="New time at starting point",

--- a/src/display/templates/display/batch_contestant_update.html
+++ b/src/display/templates/display/batch_contestant_update.html
@@ -1,0 +1,132 @@
+{% extends "base_tailwind.html" %}
+{% load tz %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="py-6">
+    <div class="card bg-base-100 shadow-xl">
+        <div class="card-body">
+            <h2 class="card-title text-2xl font-bold">Batch Update Contestants</h2>
+            <p class="text-base-content/70 mb-6">
+                Navigation Task: <strong>{{ navigation_task.name }}</strong>
+            </p>
+
+            <form method="post">
+                {% csrf_token %}
+                
+                <div class="overflow-x-auto mb-8">
+                    <table class="table table-zebra w-full">
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th>#</th>
+                                <th>Contestant</th>
+                                <th>Takeoff Time</th>
+                                <th>Wind Speed</th>
+                                <th>Wind Dir</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for contestant in contestants %}
+                            {% with calculator_started=contestant.contestanttrack.calculator_started %}
+                            <tr {% if calculator_started %}class="opacity-50"{% endif %}>
+                                <td>
+                                    {% if not calculator_started %}
+                                    <input type="checkbox" name="contestant_ids" value="{{ contestant.pk }}" class="checkbox checkbox-primary">
+                                    {% else %}
+                                    <input type="checkbox" disabled class="checkbox opacity-20">
+                                    {% endif %}
+                                </td>
+                                <td>{{ contestant.contestant_number }}</td>
+                                <td>{{ contestant }}</td>
+                                <td>{{ contestant.takeoff_time|date:"H:i" }}</td>
+                                <td>{{ contestant.wind_speed }}</td>
+                                <td>{{ contestant.wind_direction }}°</td>
+                                <td>
+                                    {% if calculator_started %}
+                                    <span class="badge badge-warning badge-sm">Running</span>
+                                    {% else %}
+                                    <span class="badge badge-success badge-sm">Ready</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endwith %}
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-8 bg-base-200 p-6 rounded-lg">
+                    <div>
+                        <h3 class="font-bold text-lg mb-4">Operation: Update Wind</h3>
+                        <div class="form-control mb-4">
+                            <label class="label cursor-pointer justify-start gap-4">
+                                {{ form.update_wind }}
+                                <span class="label-text">Apply wind update</span>
+                            </label>
+                        </div>
+                        <div class="grid grid-cols-2 gap-4">
+                            <div class="form-control">
+                                <label class="label"><span class="label-text">Wind Speed (km/h)</span></label>
+                                {{ form.wind_speed }}
+                                {% if form.wind_speed.errors %}
+                                <label class="label"><span class="label-text-alt text-error">{{ form.wind_speed.errors.0 }}</span></label>
+                                {% endif %}
+                            </div>
+                            <div class="form-control">
+                                <label class="label"><span class="label-text">Wind Direction (°)</span></label>
+                                {{ form.wind_direction }}
+                                {% if form.wind_direction.errors %}
+                                <label class="label"><span class="label-text-alt text-error">{{ form.wind_direction.errors.0 }}</span></label>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    <div>
+                        <h3 class="font-bold text-lg mb-4">Operation: Shift Times</h3>
+                        <div class="form-control mb-4">
+                            <label class="label cursor-pointer justify-start gap-4">
+                                {{ form.shift_times }}
+                                <span class="label-text">Apply time shift</span>
+                            </label>
+                        </div>
+                        <div class="form-control">
+                            <label class="label"><span class="label-text">Shift by (minutes)</span></label>
+                            {{ form.time_shift_minutes }}
+                            <span class="label-text-alt text-base-content/50 mt-1">Positive to move later, negative to move earlier.</span>
+                            {% if form.time_shift_minutes.errors %}
+                            <label class="label"><span class="label-text-alt text-error">{{ form.time_shift_minutes.errors.0 }}</span></label>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+
+                {% if form.non_field_errors %}
+                <div class="alert alert-error mt-6">
+                    <div>{{ form.non_field_errors.0 }}</div>
+                </div>
+                {% endif %}
+                
+                {% if form.contestant_ids.errors %}
+                <div class="alert alert-error mt-6">
+                    <div>Please select at least one contestant.</div>
+                </div>
+                {% endif %}
+
+                <div class="card-actions justify-end mt-8 gap-4">
+                    <a href="{% url 'navigationtask_detail' pk=navigation_task.pk %}" class="btn btn-ghost">Cancel</a>
+                    <button type="submit" class="btn btn-primary">Apply Changes</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+    // Style the inputs manually to match DaisyUI if crispy doesn't do it perfectly for non-crispy-managed fields
+    document.querySelectorAll('input[type="number"], input[type="text"]').forEach(el => {
+        el.classList.add('input', 'input-bordered', 'w-full');
+    });
+</script>
+{% endblock %}

--- a/src/display/templates/display/navigationtask_detail.html
+++ b/src/display/templates/display/navigationtask_detail.html
@@ -82,6 +82,8 @@
                                 <li><a href="{% url 'navigationtask_refresheditableroute' object.pk %}">Reload route</a></li>
                             {% endif %}
                             <li><hr class="my-1 border-base-200"></li>
+                                <li><a href="{% url 'batch_update_contestants' object.pk %}">Batch update contestants</a></li>
+                            <li><hr class="my-1 border-base-200"></li>
                             <li><a href="{% url 'navigationtask_flightorderconfiguration' object.pk %}">Flight order configuration</a></li>
                             <li><hr class="my-1 border-base-200"></li>
                             <li><a href="{% url 'navigationtask_update' object.pk %}">Update</a></li>

--- a/src/display/urls.py
+++ b/src/display/urls.py
@@ -6,6 +6,7 @@ from display.views import (
     renew_token,
     NavigationTaskDetailView,
     ContestantRecalculateWithStartTimeView,
+    BatchContestantUpdateView,
     ContestantUpdateView,
     ContestantCreateView,
     ContestantQuickAddView,
@@ -148,6 +149,11 @@ urlpatterns = [
     path("contest/<int:pk>/update/", ContestUpdateView.as_view(), name="contest_update"),
     path("contest/<int:pk>/share/", share_contest, name="contest_share"),
     path("navigationtask/<int:pk>/", NavigationTaskDetailView.as_view(), name="navigationtask_detail"),
+    path(
+        "navigationtask/<int:navigationtask_pk>/batch_update_contestants/",
+        BatchContestantUpdateView.as_view(),
+        name="batch_update_contestants",
+    ),
     path(
         "navigationtask/<int:pk>/restorescorecard/",
         navigation_task_restore_original_scorecard_view,

--- a/src/display/views.py
+++ b/src/display/views.py
@@ -1504,7 +1504,62 @@ class ContestantRecalculateWithStartTimeView(GuardianPermissionRequiredMixin, Fo
         return reverse("navigationtask_detail", kwargs={"pk": self.contestant.navigation_task.pk})
 
 
-class ContestantUpdateView(ContestantTimeZoneMixin, GuardianPermissionRequiredMixin, UpdateView):
+from django.contrib import messages
+from django.shortcuts import get_object_or_404, redirect, render
+from django.views import View
+from django.contrib.auth.mixins import LoginRequiredMixin
+from guardian.mixins import GuardianPermissionRequiredMixin
+from .models import NavigationTask, Contestant
+from .forms import BatchContestantUpdateForm
+from datetime import timedelta
+
+class BatchContestantUpdateView(LoginRequiredMixin, GuardianPermissionRequiredMixin, View):
+    template_name = "display/batch_contestant_update.html"
+    permission_required = ("display.change_contest",)
+
+    def get_permission_object(self):
+        return get_object_or_404(NavigationTask, pk=self.kwargs["navigationtask_pk"]).contest
+
+    def get(self, request, navigationtask_pk):
+        navigation_task = get_object_or_404(NavigationTask, pk=navigationtask_pk)
+        contestants = navigation_task.contestant_set.select_related("contestanttrack", "team__crew__member").order_by("takeoff_time")
+        form = BatchContestantUpdateForm(navigation_task=navigation_task)
+        return render(request, self.template_name, {
+            "navigation_task": navigation_task,
+            "contestants": contestants,
+            "form": form,
+        })
+
+    def post(self, request, navigationtask_pk):
+        navigation_task = get_object_or_404(NavigationTask, pk=navigationtask_pk)
+        contestants_qs = navigation_task.contestant_set.select_related("contestanttrack", "team__crew__member").order_by("takeoff_time")
+        form = BatchContestantUpdateForm(request.POST, navigation_task=navigation_task)
+        if form.is_valid():
+            cd = form.cleaned_data
+            ids = [int(i) for i in cd["contestant_ids"]]
+            delta = timedelta(minutes=float(cd["time_shift_minutes"])) if cd.get("shift_times") and cd.get("time_shift_minutes") is not None else None
+            updated = 0
+            for c in navigation_task.contestant_set.select_related("contestanttrack").filter(pk__in=ids):
+                if hasattr(c, "contestanttrack") and c.contestanttrack.calculator_started:
+                    continue
+                if cd.get("update_wind"):
+                    c.wind_speed = cd["wind_speed"]
+                    c.wind_direction = cd["wind_direction"]
+                    c.predefined_gate_times = None
+                if delta is not None:
+                    c.tracker_start_time += delta
+                    c.takeoff_time += delta
+                    c.finished_by_time += delta
+                    c.predefined_gate_times = None
+                c.save()
+                updated += 1
+            messages.success(request, f"Updated {updated} contestant(s).")
+            return redirect("navigationtask_detail", pk=navigationtask_pk)
+        return render(request, self.template_name, {
+            "navigation_task": navigation_task,
+            "contestants": contestants_qs,
+            "form": form,
+        })
     form_class = ContestantForm
     model = Contestant
     permission_required = ("display.change_contest",)


### PR DESCRIPTION
## Summary

Adds a **Batch Update Contestants** page so navigation task managers can apply bulk modifications to multiple contestants at once, instead of editing them one by one.

## Changes

- `forms.py`: `BatchContestantUpdateForm` — multi-select contestants + wind/time-shift fields with validation
- `views.py`: `BatchContestantUpdateView` — GET lists contestants, POST applies updates atomically per contestant
- `batch_contestant_update.html`: Table of contestants with checkboxes (locked contestants shown but disabled), operation form below
- `urls.py`: Route `navigationtask/<pk>/batch_update_contestants/`
- `navigationtask_detail.html`: Batch Update button added to the management dropdown

## Operations supported

- **Update wind**: Sets `wind_speed` and `wind_direction`; clears `predefined_gate_times` to trigger recalculation
- **Shift times**: Moves `tracker_start_time`, `takeoff_time`, and `finished_by_time` forward or backward by N minutes; also clears `predefined_gate_times`

Contestants where `contestanttrack.calculator_started=True` are displayed but cannot be selected.

Fixes #108