### PR TITLE
Point TodaysFlights API_BASE at app.airsports.no

### DIFF
--- a/airsports_static/src/components/TodaysFlights.astro
+++ b/airsports_static/src/components/TodaysFlights.astro
@@ -36,9 +36,9 @@
         
         if (!container || !list || !dateDisplay) return;
 
-        const API_BASE = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1' 
-            ? 'http://localhost:8002' 
-            : 'https://airsports.no';
+        const API_BASE = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+            ? 'http://localhost:8002'
+            : 'https://app.airsports.no';
 
         dateDisplay.textContent = new Date().toLocaleDateString('en-GB', { weekday: 'long', month: 'short', day: 'numeric' });
 


### PR DESCRIPTION
## Summary
- Updates the production `API_BASE` in `TodaysFlights.astro` from `https://airsports.no` to `https://app.airsports.no`.
- Catches up the marketing site after today's CDN migration, where API and competition-map links moved to the `app` sub-domain.

## Why
With the API endpoints (`/api/v1/contests/todays_navigation/`) now living on `app.airsports.no` only, the marketing homepage's Today's Missions cards were:
1. Failing to fetch (`airsports.no/api/...` no longer routes to the application).
2. Generating "Open Live Map" buttons pointing at the wrong host.

Both problems are resolved by the single change to `API_BASE`.

## Out of scope (flagged for follow-up)
The same fallback constant exists in `LiveTicker.astro` and the newsletter form in `index.astro`. They have the same migration debt but were not part of this request — happy to bundle them into a separate PR.

## Test plan
- [ ] `npm run dev` in `airsports_static/`, load the homepage, confirm Today's Missions section populates and the "Open Live Map" button targets `app.airsports.no`.
- [ ] Verify on staging deploy once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)