### PR TITLE
helm: increase redis-ha haproxy check timeout

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -155,6 +155,12 @@ redis:
   haproxy:
     enabled: true
     replicas: 2
+
+    # Tuning: reduce false DOWNs in HAProxy tcp-checks towards sentinel/redis.
+    # Default in redis-ha chart is `timeout.check: 2s`, and we see 2002ms timeouts in prod logs.
+    timeout:
+      check: 5s
+
     resources:
       requests:
         cpu: 500m


### PR DESCRIPTION
Context: #113 shows HAProxy tcp-check Layer7 timeouts at ~2002ms and the backend ends up with no server available. The redis-ha chart default for `haproxy.timeout.check` is `2s`.

This PR makes a minimal config tweak in our Helm values:
- set `redis.haproxy.timeout.check: 5s`

Goal: reduce false DOWNs / flapping when sentinel/redis responses are slightly slower than 2s.
