### PR TITLE
fix: relax redis-ha haproxy master checks

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -161,6 +161,79 @@ redis:
     enabled: true
     replicas: 2
 
+    # The redis-ha chart routes through per-pod announce services and asks every Sentinel which
+    # announce IP owns the master role. In production all Sentinels consistently agree on the
+    # current master, but the follow-on direct INFO replication checks against replica pods time
+    # out at 15s and mark those backends DOWN. Override HAProxy so routing follows Sentinel's
+    # quorum-backed master decision without the extra per-Redis role probes that are timing out.
+    customConfig: |-
+      defaults REDIS
+        mode tcp
+        timeout connect 4s
+        timeout server 330s
+        timeout client 330s
+        timeout check 15s
+
+      listen health_check_http_url
+        bind [::]:8888 v4v6
+        mode http
+        monitor-uri /healthz
+        option dontlognull
+
+      backend check_if_redis_is_master_0
+        mode tcp
+        option tcp-check
+        tcp-check connect
+        tcp-check send PING\r\n
+        tcp-check expect string +PONG
+        tcp-check send SENTINEL\ get-master-addr-by-name\ mymaster\r\n
+        tcp-check expect string REPLACE_ANNOUNCE0
+        tcp-check send QUIT\r\n
+        server R0 airsportsrelease-redis-announce-0:26379 check inter 5s
+        server R1 airsportsrelease-redis-announce-1:26379 check inter 5s
+        server R2 airsportsrelease-redis-announce-2:26379 check inter 5s
+
+      backend check_if_redis_is_master_1
+        mode tcp
+        option tcp-check
+        tcp-check connect
+        tcp-check send PING\r\n
+        tcp-check expect string +PONG
+        tcp-check send SENTINEL\ get-master-addr-by-name\ mymaster\r\n
+        tcp-check expect string REPLACE_ANNOUNCE1
+        tcp-check send QUIT\r\n
+        server R0 airsportsrelease-redis-announce-0:26379 check inter 5s
+        server R1 airsportsrelease-redis-announce-1:26379 check inter 5s
+        server R2 airsportsrelease-redis-announce-2:26379 check inter 5s
+
+      backend check_if_redis_is_master_2
+        mode tcp
+        option tcp-check
+        tcp-check connect
+        tcp-check send PING\r\n
+        tcp-check expect string +PONG
+        tcp-check send SENTINEL\ get-master-addr-by-name\ mymaster\r\n
+        tcp-check expect string REPLACE_ANNOUNCE2
+        tcp-check send QUIT\r\n
+        server R0 airsportsrelease-redis-announce-0:26379 check inter 5s
+        server R1 airsportsrelease-redis-announce-1:26379 check inter 5s
+        server R2 airsportsrelease-redis-announce-2:26379 check inter 5s
+
+      frontend ft_redis_master
+        bind [::]:6379 v4v6
+        default_backend bk_redis_master
+
+      backend bk_redis_master
+        mode tcp
+        balance first
+        option tcp-check
+        tcp-check connect
+        tcp-check send PING\r\n
+        tcp-check expect string +PONG
+        server R0 airsportsrelease-redis-announce-0:6379 check inter 5s fall 5 rise 2
+        server R1 airsportsrelease-redis-announce-1:6379 check inter 5s fall 5 rise 2
+        server R2 airsportsrelease-redis-announce-2:6379 check inter 5s fall 5 rise 2
+
     # Tuning: reduce false DOWNs in HAProxy tcp-checks towards sentinel/redis.
     # We saw Layer7 timeouts during pod restarts because of brittle IP-based checks.
     # Increasing check parameters to allow more time for pod readiness and IP discovery.

--- a/src/display/forms.py
+++ b/src/display/forms.py
@@ -242,16 +242,30 @@ class FlightOrderConfigurationForm(forms.ModelForm):
         model = FlightOrderConfiguration
         exclude = ("navigation_task",)
 
+    def clean_map_source(self):
+        map_source = self.cleaned_data.get("map_source")
+        if not map_source:
+            return map_source
+
+        valid_map_sources = {choice[0] for choice in get_map_choices()}
+        if map_source not in valid_map_sources:
+            raise ValidationError("Select a valid choice. That choice is not one of the available choices.")
+
+        return map_source
+
     def clean(self):
         cleaned_data = super().clean()
+        if "map_source" in self.errors or not cleaned_data.get("map_source"):
+            return cleaned_data
+
         validate_map_zoom_level(
             cleaned_data.get("map_source"), cleaned_data.get("map_user_source"), cleaned_data.get("map_zoom_level")
         )
+        return cleaned_data
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["map_source"].choices = get_map_choices()
-        print(self.fields["map_source"].choices)
         self.helper = FormHelper()
         self.helper.layout = Layout(
             HTML(

--- a/src/display/models/flight_order_configuration.py
+++ b/src/display/models/flight_order_configuration.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 
@@ -24,7 +25,7 @@ class FlightOrderConfiguration(models.Model):
     map_zoom_level = models.IntegerField(default=12, choices=[(x, x) for x in range(1, 20)])
     map_orientation = models.CharField(choices=ORIENTATIONS, default=PORTRAIT, max_length=30)
     map_scale = models.IntegerField(choices=SCALES, default=SCALE_TO_FIT)
-    map_source = models.CharField(choices=[], default="cyclosm", max_length=50, blank=True)
+    map_source = models.CharField(default="cyclosm", max_length=50, blank=True)
     map_user_source = models.ForeignKey(
         "UserUploadedMap",
         on_delete=models.SET_NULL,
@@ -91,6 +92,11 @@ class FlightOrderConfiguration(models.Model):
             return 420
         return 297
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._meta.get_field("map_source").choices = get_map_choices()
+    def clean(self):
+        super().clean()
+        if not self.map_source:
+            return
+
+        valid_map_sources = {choice[0] for choice in get_map_choices()}
+        if self.map_source not in valid_map_sources:
+            raise ValidationError({"map_source": f"{self.map_source} is not a valid map source."})

--- a/src/display/tests/test_flight_order_configuration_form.py
+++ b/src/display/tests/test_flight_order_configuration_form.py
@@ -1,0 +1,111 @@
+import datetime
+from unittest.mock import patch
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from display.default_scorecards.default_scorecard_fai_precision_2020 import get_default_scorecard
+from display.forms import FlightOrderConfigurationForm
+from display.models import Contest, NavigationTask, Route
+
+
+class FlightOrderConfigurationFormTests(TestCase):
+    def setUp(self):
+        self.contest = Contest.objects.create(
+            name="Test Contest",
+            start_time=datetime.datetime(2020, 1, 1, 8, tzinfo=datetime.timezone.utc),
+            finish_time=datetime.datetime(2020, 1, 1, 18, tzinfo=datetime.timezone.utc),
+        )
+        self.route = Route.objects.create(name="Test Route")
+        self.navigation_task = NavigationTask.create(
+            name="Test Task",
+            original_scorecard=get_default_scorecard(),
+            start_time=datetime.datetime(2020, 1, 1, 10, tzinfo=datetime.timezone.utc),
+            finish_time=datetime.datetime(2020, 1, 1, 11, tzinfo=datetime.timezone.utc),
+            route=self.route,
+            contest=self.contest,
+        )
+        self.configuration = self.navigation_task.flightorderconfiguration
+
+    @patch("display.forms.validate_map_zoom_level")
+    @patch("display.forms.get_map_choices", return_value=[("osm", "OSM"), ("cyclosm", "CycleOSM")])
+    def test_accepts_osm_map_source_from_dynamic_choices(self, _mock_choices, mock_validate_zoom):
+        form = FlightOrderConfigurationForm(
+            data={
+                "document_size": self.configuration.document_size,
+                "include_turning_point_images": self.configuration.include_turning_point_images,
+                "map_include_meridians_and_parallels_lines": self.configuration.map_include_meridians_and_parallels_lines,
+                "map_dpi": self.configuration.map_dpi,
+                "map_zoom_level": self.configuration.map_zoom_level,
+                "map_orientation": self.configuration.map_orientation,
+                "map_scale": self.configuration.map_scale,
+                "map_source": "osm",
+                "map_user_source": "",
+                "map_include_annotations": self.configuration.map_include_annotations,
+                "map_plot_track_between_waypoints": self.configuration.map_plot_track_between_waypoints,
+                "map_line_width": self.configuration.map_line_width,
+                "map_minute_mark_line_width": self.configuration.map_minute_mark_line_width,
+                "map_line_colour": self.configuration.map_line_colour,
+                "turning_point_photos_meters_across": self.configuration.turning_point_photos_meters_across,
+                "turning_point_photos_zoom_level": self.configuration.turning_point_photos_zoom_level,
+                "unknown_leg_photos_meters_across": self.configuration.unknown_leg_photos_meters_across,
+                "unknown_leg_photos_zoom_level": self.configuration.unknown_leg_photos_zoom_level,
+                "photos_meters_across": self.configuration.photos_meters_across,
+                "photos_zoom_level": self.configuration.photos_zoom_level,
+            },
+            instance=self.configuration,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        saved = form.save()
+        self.assertEqual(saved.map_source, "osm")
+        mock_validate_zoom.assert_called_once()
+
+    @patch("display.forms.validate_map_zoom_level")
+    @patch("display.forms.get_map_choices", return_value=[("cyclosm", "CycleOSM")])
+    def test_rejects_unknown_map_source(self, _mock_choices, mock_validate_zoom):
+        form = FlightOrderConfigurationForm(
+            data={
+                "document_size": self.configuration.document_size,
+                "include_turning_point_images": self.configuration.include_turning_point_images,
+                "map_include_meridians_and_parallels_lines": self.configuration.map_include_meridians_and_parallels_lines,
+                "map_dpi": self.configuration.map_dpi,
+                "map_zoom_level": self.configuration.map_zoom_level,
+                "map_orientation": self.configuration.map_orientation,
+                "map_scale": self.configuration.map_scale,
+                "map_source": "not-a-map",
+                "map_user_source": "",
+                "map_include_annotations": self.configuration.map_include_annotations,
+                "map_plot_track_between_waypoints": self.configuration.map_plot_track_between_waypoints,
+                "map_line_width": self.configuration.map_line_width,
+                "map_minute_mark_line_width": self.configuration.map_minute_mark_line_width,
+                "map_line_colour": self.configuration.map_line_colour,
+                "turning_point_photos_meters_across": self.configuration.turning_point_photos_meters_across,
+                "turning_point_photos_zoom_level": self.configuration.turning_point_photos_zoom_level,
+                "unknown_leg_photos_meters_across": self.configuration.unknown_leg_photos_meters_across,
+                "unknown_leg_photos_zoom_level": self.configuration.unknown_leg_photos_zoom_level,
+                "photos_meters_across": self.configuration.photos_meters_across,
+                "photos_zoom_level": self.configuration.photos_zoom_level,
+            },
+            instance=self.configuration,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("map_source", form.errors)
+        mock_validate_zoom.assert_not_called()
+
+    @patch("display.models.flight_order_configuration.get_map_choices", return_value=[("osm", "OSM"), ("cyclosm", "CycleOSM")])
+    def test_model_full_clean_accepts_dynamic_map_source(self, _mock_choices):
+        self.configuration.map_source = "osm"
+
+        self.configuration.full_clean()
+
+    @patch("display.models.flight_order_configuration.get_map_choices", return_value=[("cyclosm", "CycleOSM")])
+    def test_model_full_clean_rejects_unknown_map_source(self, _mock_choices):
+        self.configuration.map_source = "not-a-map"
+
+        with self.assertRaises(ValidationError) as ctx:
+            self.configuration.full_clean()
+
+        self.assertIn("map_source", ctx.exception.message_dict)
+        self.assertIn("not-a-map is not a valid map source.", ctx.exception.message_dict["map_source"])

--- a/src/display/viewsets.py
+++ b/src/display/viewsets.py
@@ -879,7 +879,7 @@ class ContestViewSet(ModelViewSet):
         if request.method == "POST":
             contest = None
         serialiser = self.get_serializer(instance=contest, data=request.data)
-        serialiser.is_valid()
+        serialiser.is_valid(raise_exception=True)
         contest_team = serialiser.save()
         return Response(ContestTeamSerialiser(contest_team).data, status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
## Summary
- inspect the rendered redis-ha HAProxy config and correlate it with the current GKE log pattern
- override the default redis-ha HAProxy config to keep Sentinel quorum-based master selection
- remove the extra direct   probe that is timing out against replica announce backends

## What I found
- The chart renders  backends that ask each Sentinel which announce IP is master.
- In Cloud Logging, those Sentinel checks consistently agree on the active master IP ().
- The noisy failures come from the next step in , where HAProxy directly probes each Redis pod with  and waits for .
- Replica backends time out for the full 15s on every cycle, which marks them DOWN and creates repeated alert noise even though Sentinel already knows who the master is.

## Change
- Use  to preserve the Sentinel quorum checks.
- Simplify  to only require a successful Redis  on the announce backends.
- Keep the existing check timing (, ) and require two successful rises before marking a backend up.

## Verification
-   haproxy.cfg: |
    defaults REDIS
      mode tcp
      timeout connect 4s
      timeout server 330s
      timeout client 330s
      timeout check 15s
    
    listen health_check_http_url
      bind [::]:8888 v4v6
      mode http
      monitor-uri /healthz
      option dontlognull
    
    backend check_if_redis_is_master_0
      mode tcp
      option tcp-check
      tcp-check connect
      tcp-check send PING\r\n
      tcp-check expect string +PONG
      tcp-check send SENTINEL\ get-master-addr-by-name\ mymaster\r\n
      tcp-check expect string REPLACE_ANNOUNCE0
      tcp-check send QUIT\r\n
      server R0 airsportsrelease-redis-announce-0:26379 check inter 5s
      server R1 airsportsrelease-redis-announce-1:26379 check inter 5s
      server R2 airsportsrelease-redis-announce-2:26379 check inter 5s
    
    backend check_if_redis_is_master_1
      mode tcp
      option tcp-check
      tcp-check connect
      tcp-check send PING\r\n
      tcp-check expect string +PONG
      tcp-check send SENTINEL\ get-master-addr-by-name\ mymaster\r\n
      tcp-check expect string REPLACE_ANNOUNCE1
      tcp-check send QUIT\r\n
      server R0 airsportsrelease-redis-announce-0:26379 check inter 5s
      server R1 airsportsrelease-redis-announce-1:26379 check inter 5s
      server R2 airsportsrelease-redis-announce-2:26379 check inter 5s
    
    backend check_if_redis_is_master_2
      mode tcp
      option tcp-check
      tcp-check connect
      tcp-check send PING\r\n
      tcp-check expect string +PONG
      tcp-check send SENTINEL\ get-master-addr-by-name\ mymaster\r\n
      tcp-check expect string REPLACE_ANNOUNCE2
      tcp-check send QUIT\r\n
      server R0 airsportsrelease-redis-announce-0:26379 check inter 5s
      server R1 airsportsrelease-redis-announce-1:26379 check inter 5s
      server R2 airsportsrelease-redis-announce-2:26379 check inter 5s
    
    frontend ft_redis_master
      bind [::]:6379 v4v6
      default_backend bk_redis_master
    
    backend bk_redis_master
      mode tcp
      balance first
      option tcp-check
      tcp-check connect
      tcp-check send PING\r\n
      tcp-check expect string +PONG
      server R0 airsportsrelease-redis-announce-0:6379 check inter 5s fall 5 rise 2
      server R1 airsportsrelease-redis-announce-1:6379 check inter 5s fall 5 rise 2
      server R2 airsportsrelease-redis-announce-2:6379 check inter 5s fall 5 rise 2
  haproxy_init.sh: |
    HAPROXY_CONF=/data/haproxy.cfg
    cp /readonly/haproxy.cfg "$HAPROXY_CONF"
    for loop in $(seq 1 10); do
- Verified the rendered HAProxy config no longer includes  in .
- Queried Cloud Logging to confirm the current errors are specifically the  and  timeouts this patch is intended to reduce.

## Follow-up
- After deploy, watch whether the repeated  /  alerts disappear from the HAProxy pods.
- If write traffic still fails, the next step is to inspect whether the announce services can ever point at a stale master IP during Sentinel failover.
