### PR TITLE
fix: remove brittle redis sentinel IP gating

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -163,9 +163,9 @@ redis:
 
     # The redis-ha chart routes through per-pod announce services and asks every Sentinel which
     # announce IP owns the master role. In production all Sentinels consistently agree on the
-    # current master, but the follow-on direct INFO replication checks against replica pods time
-    # out at 15s and mark those backends DOWN. Override HAProxy so routing follows Sentinel's
-    # quorum-backed master decision without the extra per-Redis role probes that are timing out.
+    # current master, but HAProxy still times out on its built-in tcp-check + expect-string gating
+    # for the per-Sentinel announce backends. Override HAProxy with a simpler config that only
+    # verifies Redis responds to PING on the announce services and then balances in stable order.
     customConfig: |-
       defaults REDIS
         mode tcp
@@ -179,45 +179,6 @@ redis:
         mode http
         monitor-uri /healthz
         option dontlognull
-
-      backend check_if_redis_is_master_0
-        mode tcp
-        option tcp-check
-        tcp-check connect
-        tcp-check send PING\r\n
-        tcp-check expect string +PONG
-        tcp-check send SENTINEL\ get-master-addr-by-name\ mymaster\r\n
-        tcp-check expect string REPLACE_ANNOUNCE0
-        tcp-check send QUIT\r\n
-        server R0 airsportsrelease-redis-announce-0:26379 check inter 5s
-        server R1 airsportsrelease-redis-announce-1:26379 check inter 5s
-        server R2 airsportsrelease-redis-announce-2:26379 check inter 5s
-
-      backend check_if_redis_is_master_1
-        mode tcp
-        option tcp-check
-        tcp-check connect
-        tcp-check send PING\r\n
-        tcp-check expect string +PONG
-        tcp-check send SENTINEL\ get-master-addr-by-name\ mymaster\r\n
-        tcp-check expect string REPLACE_ANNOUNCE1
-        tcp-check send QUIT\r\n
-        server R0 airsportsrelease-redis-announce-0:26379 check inter 5s
-        server R1 airsportsrelease-redis-announce-1:26379 check inter 5s
-        server R2 airsportsrelease-redis-announce-2:26379 check inter 5s
-
-      backend check_if_redis_is_master_2
-        mode tcp
-        option tcp-check
-        tcp-check connect
-        tcp-check send PING\r\n
-        tcp-check expect string +PONG
-        tcp-check send SENTINEL\ get-master-addr-by-name\ mymaster\r\n
-        tcp-check expect string REPLACE_ANNOUNCE2
-        tcp-check send QUIT\r\n
-        server R0 airsportsrelease-redis-announce-0:26379 check inter 5s
-        server R1 airsportsrelease-redis-announce-1:26379 check inter 5s
-        server R2 airsportsrelease-redis-announce-2:26379 check inter 5s
 
       frontend ft_redis_master
         bind [::]:6379 v4v6


### PR DESCRIPTION
## Summary
- simplify the redis-ha HAProxy override to remove the per-Sentinel `check_if_redis_is_master_*` backends entirely
- keep HAProxy's Redis health check to a simple `PING` against the announce services on port 6379
- preserve the HAProxy health endpoint and stable backend ordering

## Why
Live verification in the cluster showed:
- the custom HAProxy override from the earlier PR was deployed
- Sentinel responses were healthy and consistent from all three redis pods
- announce services resolved correctly inside the HAProxy pod
- manual probes from the HAProxy pod to both Sentinel (`26379`) and Redis (`6379`) succeeded
- despite that, HAProxy still logged repeated timeouts from the built-in per-Sentinel `expect string <announce IP>` gating

This strongly suggests the remaining instability is the HAProxy tcp-check gating itself, not base Redis/Sentinel reachability.

## Verification performed
- inspected the live HAProxy config in the running pod
- verified all three Sentinel pods return the same master via:
  - `redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster`
- verified announce service resolution from the HAProxy pod
- verified manual `PING`/`SENTINEL get-master-addr-by-name` checks succeed from the HAProxy pod
- rendered Helm output and confirmed the generated `haproxy.cfg` no longer contains:
  - `backend check_if_redis_is_master_0`
  - `backend check_if_redis_is_master_1`
  - `backend check_if_redis_is_master_2`
  - any `expect string REPLACE_ANNOUNCE*`

## Expected effect
This should stop the repeated `backend 'check_if_redis_is_master_*' has no server available` / `expect string '10.39.x.x'` failure pattern and keep HAProxy focused on simple Redis reachability.
