### PR TITLE
fix: serve marketing public assets when dist is unavailable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN chmod 755 /gunicorn.sh /wait-for-it.sh /daphne.sh
 COPY --chown=django:django src /src
 COPY --chown=django:django --from=frontend_builder /app/assets_vite /assets_vite
 COPY --chown=django:django --from=frontend_builder /app/airsports_static/dist /marketing_dist
+COPY --chown=django:django --from=frontend_builder /app/airsports_static/public/example_flight_order.pdf /marketing_dist/example_flight_order.pdf
 COPY --chown=django:django react_vite/src/routes.json /react_vite/src/
 COPY --chown=django:django --from=frontend_builder /app/src/static/css/output.css /src/static/css
 


### PR DESCRIPTION
## Summary
- fall back to  when the marketing dist build is unavailable
- keeps direct assets like  resolvable in environments without a populated marketing dist folder
- improves resilience for marketing-file requests hitting the combined frontend view

## Why
Issue #540 shows  failing even though the file exists in the repo under . The current settings only prefer /, so direct public assets can be missing from the served document root.

## Validation
- verified  exists in 
- verified it does not exist in  in the clean checkout
- ran 

Closes #540