### PR TITLE
fix: tolerate tracker-processor redis heartbeat failures

### DIFF
--- a/src/position_processor_process.py
+++ b/src/position_processor_process.py
@@ -62,7 +62,10 @@ def print_contestant_positions_debug():
         )
         global_received_positions = 0
         last_debug = time.time()
-        cache.set(LAST_DEBUG_KEY, last_debug, 10 * DEBUG_INTERVAL)
+        try:
+            cache.set(LAST_DEBUG_KEY, last_debug, 10 * DEBUG_INTERVAL)
+        except Exception:
+            logger.warning("Unable to persist position processor heartbeat to Redis cache", exc_info=True)
 
 
 def cached_find_contestant(device_name: str, device_time: datetime.datetime) -> List[Tuple[Contestant, bool]]:
@@ -109,7 +112,10 @@ def clean_db_positions():
 
 
 def initial_processor(queue: Queue, global_map_queue: Queue):
-    cache.set(LAST_DEBUG_KEY, last_debug, 10 * DEBUG_INTERVAL)
+    try:
+        cache.set(LAST_DEBUG_KEY, last_debug, 10 * DEBUG_INTERVAL)
+    except Exception:
+        logger.warning("Unable to initialize position processor heartbeat in Redis cache", exc_info=True)
 
     connections.close_all()
     while True:


### PR DESCRIPTION
## Summary
- guard tracker-processor heartbeat cache writes so transient Redis failures do not crash the processor thread
- log Redis heartbeat write failures as warnings with stack traces instead of letting them bubble up as uncaught exceptions

## Why
Issue #541 shows `tracker-processor` logging Redis connection stacktraces rooted in `position_processor_process.py` around `LAST_DEBUG_KEY` heartbeat handling. The processor uses Redis-backed Django cache for a liveness/debug heartbeat, but that heartbeat is non-critical. If Redis/HAProxy is briefly unavailable, the processor should continue processing positions and only degrade heartbeat visibility.

## Validation
- pulled clean `main`
- inspected `src/position_processor_process.py`
- ran `python3 -m py_compile src/position_processor_process.py`

Closes #541