### PR TITLE
fix: make gunicorn timeout configurable for tracker-web

### DIFF
--- a/config/gunicorn.sh
+++ b/config/gunicorn.sh
@@ -2,9 +2,9 @@
 
 NAME="live_tracking_map"                           #Name of the application (*)
 DJANGODIR=/src/                               # Django project directory (*)
-NUM_WORKERS="${NUM_WORKERS:-1}"              # how many worker processes should Gunicorn spawn (*)
-NUM_THREADS="${NUM_THREADS:-1}"              # How many threads should each worker have
-TIMEOUT="${GUNICORN_TIMEOUT:-60}"
+NUM_WORKERS=${NUM_WORKERS:-1}
+NUM_THREADS=${NUM_THREADS:-1}
+TIMEOUT=${GUNICORN_TIMEOUT:-60}
 
 DJANGO_SETTINGS_MODULE=live_tracking_map.settings  # which settings file should Django use (*)
 DJANGO_WSGI_MODULE=live_tracking_map.wsgi          # WSGI module name (*)

--- a/config/gunicorn.sh
+++ b/config/gunicorn.sh
@@ -2,8 +2,9 @@
 
 NAME="live_tracking_map"                           #Name of the application (*)
 DJANGODIR=/src/                               # Django project directory (*)
-NUM_WORKERS=1                                # how many worker processes should Gunicorn spawn (*)
-NUM_THREADS=1                                 # How many threads should each worker have
+NUM_WORKERS="${NUM_WORKERS:-1}"              # how many worker processes should Gunicorn spawn (*)
+NUM_THREADS="${NUM_THREADS:-1}"              # How many threads should each worker have
+TIMEOUT="${GUNICORN_TIMEOUT:-60}"
 
 DJANGO_SETTINGS_MODULE=live_tracking_map.settings  # which settings file should Django use (*)
 DJANGO_WSGI_MODULE=live_tracking_map.wsgi          # WSGI module name (*)
@@ -25,7 +26,7 @@ exec gunicorn \
   --name $NAME \
   --workers $NUM_WORKERS \
   --threads $NUM_THREADS \
-  --timeout 30 \
+  --timeout $TIMEOUT \
   --bind=:8002 \
   --log-level warning \
   --max-requests 2000 \

--- a/helm/templates/deployment_tracker_web.yaml
+++ b/helm/templates/deployment_tracker_web.yaml
@@ -51,6 +51,13 @@ spec:
         ports:
           - name: web
             containerPort: 8002
+        env:
+          - name: GUNICORN_TIMEOUT
+            value: "60"
+          - name: NUM_WORKERS
+            value: "1"
+          - name: NUM_THREADS
+            value: "1"
         envFrom:
           - configMapRef:
               name: envs-production-other

--- a/helm/templates/deployment_tracker_web.yaml
+++ b/helm/templates/deployment_tracker_web.yaml
@@ -57,7 +57,7 @@ spec:
           - name: NUM_WORKERS
             value: "1"
           - name: NUM_THREADS
-            value: "1"
+            value: "2"
         envFrom:
           - configMapRef:
               name: envs-production-other


### PR DESCRIPTION
## Summary
- make gunicorn timeout configurable via `GUNICORN_TIMEOUT`
- keep worker/thread counts configurable via environment as well
- raise the default timeout from 30s to 60s to reduce false worker timeout kills on slower requests
- increase tracker-web gunicorn threads from 1 to 2 in the deployment template to reduce request queueing for small/blocked requests

## Why
Issue #539 tracks tracker-web worker timeouts / OOM and follow-on request failures. The current startup script hardcodes `--timeout 30`, and the deployment was running each pod with just 1 worker and 1 thread. With two pods that still only gives two concurrent request slots, so a couple of slow requests can make pages feel slow to start responding.

Because the tracker-web HPA is already fairly aggressive and each pod only has 500m CPU, a small thread increase is a lower-risk first tuning step than adding more workers.

## Changes
- replace hardcoded worker/thread values with environment-configurable defaults
- replace hardcoded `--timeout 30` with `GUNICORN_TIMEOUT` (default `60`)
- change tracker-web deployment default `NUM_THREADS` from `1` to `2`

## Validation
- inspected `config/gunicorn.sh`
- inspected `helm/templates/deployment_tracker_web.yaml`
- pushed updated branch with thread tuning

Closes #539