### PR TITLE
fix: reduce calculator termination log noise

### DIFF
--- a/src/display/calculators/contestant_processor.py
+++ b/src/display/calculators/contestant_processor.py
@@ -511,8 +511,14 @@ class ContestantProcessor:
         """
         Trigger termination of the run function.
         """
-        stack_trace = "".join(traceback.format_stack())
-        logger.info(f"{self.contestant}: Setting termination flag. Reason: {reason}. Stack trace:\n{stack_trace}")
+        logger.info("%s: Setting termination flag. Reason: %s", self.contestant, reason or "unspecified")
+        if logger.isEnabledFor(logging.DEBUG):
+            stack_trace = "".join(traceback.format_stack(limit=12))
+            logger.debug(
+                "%s: Calculator termination stack:\n%s",
+                self.contestant,
+                stack_trace,
+            )
         self.contestant_track.set_calculator_finished()
         self.track_terminated = True
         self.timed_queue.close()

--- a/src/display/models/contestant_track.py
+++ b/src/display/models/contestant_track.py
@@ -1,8 +1,11 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import F
+import logging
 
 from display.utilities.db_retry import retry_on_lock_timeout
+
+logger = logging.getLogger(__name__)
 
 
 class ContestantTrack(models.Model):
@@ -132,9 +135,18 @@ class ContestantTrack(models.Model):
             self.__push_change()
 
     def set_calculator_finished(self):
+        rows_updated = type(self).objects.filter(pk=self.pk).update(
+            calculator_finished=True,
+            current_state="Finished",
+        )
+        if rows_updated == 0:
+            logger.warning(
+                "ContestantTrack %s disappeared before set_calculator_finished() could persist state; suppressing shutdown noise",
+                self.pk,
+            )
+            return
         self.calculator_finished = True
         self.current_state = "Finished"
-        self.save(update_fields=["calculator_finished", "current_state"])
         self.__push_change()
 
     def set_calculator_started(self):


### PR DESCRIPTION
## Summary
- keep the existing stale-row suppression in `ContestantTrack.set_calculator_finished()`
- stop logging a full stack trace for expected calculator termination events at info level
- only emit the calculator termination stack trace at debug level

## Why
The GKE error monitor is still producing a lot of calculator-job noise around manual termination and shutdown. Part of that noise came from stale-row persistence during shutdown (already mitigated on this branch), and another part comes from `notify_termination(...)` logging a full Python stack on expected/manual termination. That stack-heavy info log gets fragmented into many noisy monitor issues without adding much operational value.

## Changes
- keep the queryset-update stale-row suppression in `ContestantTrack.set_calculator_finished()`
- keep an info-level calculator termination message with the reason
- move the full calculator termination stack trace to debug level only
- cap the captured debug stack depth

## Validation
- inspected `contestant_processor.py` termination flow
- inspected `ContestantTrack.set_calculator_finished()`
- ran `python3 -m py_compile src/display/models/contestant_track.py src/display/calculators/contestant_processor.py`

Related to gke-log-monitor issues #620, #621, #622, #623, #624, #625, #626, #627, #628, #629, #637